### PR TITLE
PR with fixes to Matlab intro

### DIFF
--- a/01-intro.md
+++ b/01-intro.md
@@ -145,8 +145,8 @@ disp(weight_kg);
 and do arithmetic with it:
 
 ~~~ {.matlab}
-weight_in_pounds = 2.2 * weight_kg;
-disp(['Weight in pounds: ', num2str(weight_in_pounds)]);
+weight_in_lb = 2.2 * weight_kg;
+disp(['Weight in pounds: ', num2str(weight_in_lb)]);
 ~~~
 
 ~~~ {.output}

--- a/01-intro.md
+++ b/01-intro.md
@@ -145,8 +145,8 @@ disp(weight_kg);
 and do arithmetic with it:
 
 ~~~ {.matlab}
-weight_in_lb = 2.2 * weight_kg;
-disp(['Weight in pounds: ', num2str(weight_in_lb)]);
+weight_lb = 2.2 * weight_kg;
+disp(['Weight in pounds: ', num2str(weight_lb)]);
 ~~~
 
 ~~~ {.output}

--- a/01-intro.md
+++ b/01-intro.md
@@ -150,7 +150,7 @@ disp(['Weight in pounds: ', num2str(weight_in_pounds)]);
 ~~~
 
 ~~~ {.output}
-Weight in pounds: 121.0
+Weight in pounds: 121
 ~~~
 
 The `disp` function takes a single parameter -- the value to print. To
@@ -171,7 +171,8 @@ For example,
 ~~~ {.matlab}
 weight_kg = 57.5;
 weight_lb = 2.2 * weight_kg;
-disp(['Weight in kg: ', num2str(weight_kg); 'Weight in pounds: ', num2str(weight_lb)]);
+disp(['Weight in kg: ', num2str(weight_kg)]);
+disp(['Weight in pounds: ', num2str(weight_lb)]);
 ~~~
 
 ~~~ {.output}


### PR DESCRIPTION
These errors were only tested using Matlab 2015a on a windows system.
- on line 153, the output was 121, not 121.0
- using the one line command on line 174 gives the error:
"Error using vertcat
Dimensions of matrices being concatenated are notconsistent."
I appears that Matlab expects strings of the same length when vertically
concatenating. The simplest way to fix this was just to split the
command over 2 lines.
- I switched weight_in_pounds to weight_lb  on line 148-149 for internal consistency. Lines 222-224 will now be true