### PR TITLE
Fix errors related to reference.html

### DIFF
--- a/01-intro.html
+++ b/01-intro.html
@@ -44,7 +44,7 @@
 </ul>
 </div>
 </div>
-<p>We are studying inflammation in patients who have been given a new treatment for arthritis, and need to analyze the first dozen data sets. The data sets are stored in <a href="gloss.html#comma-separated-values">Comma Separated Values (CSV)</a> format: each row holds information for a single patient, and the columns represent successive days. The first few rows of our first file, <a href="data/inflammation-01.csv"><code>inflammation-01.csv</code></a>, look like this:</p>
+<p>We are studying inflammation in patients who have been given a new treatment for arthritis, and need to analyze the first dozen data sets. The data sets are stored in <a href="reference.html#comma-separated-values">Comma Separated Values (CSV)</a> format: each row holds information for a single patient, and the columns represent successive days. The first few rows of our first file, <a href="data/inflammation-01.csv"><code>inflammation-01.csv</code></a>, look like this:</p>
 <pre><code>0,0,1,3,1,2,4,7,8,3,3,3,10,5,7,4,7,7,12,18,6,13,11,11,7,7,4,6,8,8,4,4,5,7,3,4,2,3,0,0
 0,1,2,1,2,1,3,2,2,6,10,11,5,9,4,4,7,16,8,6,18,4,12,5,12,7,11,5,11,3,3,5,4,4,5,5,1,1,0,1
 0,1,1,3,3,2,6,2,5,9,5,7,4,5,4,15,5,11,9,10,19,14,12,17,7,12,11,7,4,2,10,5,4,2,2,3,2,2,1,1
@@ -57,7 +57,7 @@
 <li>plot the result.</li>
 </ul>
 <p>To do all that, we’ll have to learn a little bit about programming.</p>
-<p>We have a dozen datasets that need analysis, stored as <code>.csv</code> files - but MATLAB doesn’t know about these files yet. The first thing we need to do is set MATLAB’s <a href="gloss.html#matlab-path">path</a> to include the directory containing the files. The MATLAB path is a list of directories on your computer that MATLAB knows about. To do this, we go to the <code>Home</code> tab, click on <code>Set Path</code>, and then on <code>Add with Subfolders...</code>. We navigate to the directory containing our files and add it to the path to tell MATLAB where to look for our files. When you refer to a file (either code or data), MATLAB will search all the directories in the path to find it. Alternatively, for data files, we can also provide the relative or absolute file path.</p>
+<p>We have a dozen datasets that need analysis, stored as <code>.csv</code> files - but MATLAB doesn’t know about these files yet. The first thing we need to do is set MATLAB’s <a href="reference.html#matlab-path">path</a> to include the directory containing the files. The MATLAB path is a list of directories on your computer that MATLAB knows about. To do this, we go to the <code>Home</code> tab, click on <code>Set Path</code>, and then on <code>Add with Subfolders...</code>. We navigate to the directory containing our files and add it to the path to tell MATLAB where to look for our files. When you refer to a file (either code or data), MATLAB will search all the directories in the path to find it. Alternatively, for data files, we can also provide the relative or absolute file path.</p>
 <p>Before we can start programming, we need to know a little about the MATLAB interface. Using the default setup, the MATLAB desktop contains several important sections:</p>
 <ul>
 <li>In the <strong>Command Window</strong> or shell we can run and debug our code. Everything that’s typed into the command window is executed immediately.</li>
@@ -70,8 +70,8 @@
 <pre class="sourceCode matlab"><code class="sourceCode matlab">csvread(<span class="st">&#39;inflammation-01.csv&#39;</span>)</code></pre>
 <p>You should see a wall of numbers on the screen—these are the values from the CSV file. It can sometimes be useful to see the output from MATLAB commands, but it is often not. To suppress the output, simply put a semicolon at the end of your command:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">csvread(<span class="st">&#39;inflammation-01.csv&#39;</span>);</code></pre>
-<p>The expression <code>csvread(...)</code> is a <a href="gloss.html#function-call">function call</a>. Functions generally need <a href="gloss.html#parameter">parameters</a> to run. In the case of the <code>csvread</code> function, we need to provide a single parameter: the name of the file we want to read data from. This parameter needs to be a character string or <a href="gloss.html#string">string</a>, so we put it in quotes.</p>
-<p>Our call to <code>csvread</code> read our file, and printed the data inside to the screen. And adding a semicolon rendered it even less useful— we have no way to modify those values or compute with them. To do that, we need to assign the array to a <a href="gloss.html#variable">variable</a>.</p>
+<p>The expression <code>csvread(...)</code> is a <a href="reference.html#function-call">function call</a>. Functions generally need <a href="reference.html#parameter">parameters</a> to run. In the case of the <code>csvread</code> function, we need to provide a single parameter: the name of the file we want to read data from. This parameter needs to be a character string or <a href="reference.html#string">string</a>, so we put it in quotes.</p>
+<p>Our call to <code>csvread</code> read our file, and printed the data inside to the screen. And adding a semicolon rendered it even less useful— we have no way to modify those values or compute with them. To do that, we need to assign the array to a <a href="reference.html#variable">variable</a>.</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">patient_data = csvread(<span class="st">&#39;inflammation-01.csv&#39;</span>);</code></pre>
 <p>A variable is just a name for a piece of data or <em>value</em>. Variable names must begin with a letter, and can contain numbers or underscores. Examples of valid variable names are <code>x</code>, <code>f_0</code> or <code>current_temperature</code>.</p>
 <p>We can create a new variable simply by assigning a value to it using <code>=</code>:</p>
@@ -135,7 +135,7 @@ mass = mass * <span class="fl">2.0</span>
 age = age - <span class="fl">20</span></code></pre>
 </div>
 </div>
-<p>Now that our data is in memory, we can start doing things with it. First, let’s find out its size or <a href="gloss.html#shape">shape</a>:</p>
+<p>Now that our data is in memory, we can start doing things with it. First, let’s find out its size or <a href="reference.html#shape">shape</a>:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">size(patient_data)</code></pre>
 <pre class="output"><code>ans =
 
@@ -169,11 +169,11 @@ age = age - <span class="fl">20</span></code></pre>
     8   58   59    5    4   62   63    1</code></pre>
 <p>We want to access a single value from the matrix:</p>
 <p><img src="fig/matrix-single-element.svg" style="height:350px" alt="Accessing a single value"/></p>
-<p>To do that, we must provide its <a href="gloss.html#index">index</a> in brackets:</p>
+<p>To do that, we must provide its <a href="reference.html#index">index</a> in brackets:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">M(<span class="fl">5</span>, <span class="fl">6</span>)</code></pre>
 <pre class="output"><code>ans = 38</code></pre>
 <p>Indices are provided as (row, column). So the index <code>(5, 6)</code> selects the element on the fifth row and sixth column.</p>
-<p>An index like <code>(5, 6)</code> selects a single element of an array, but we can also access sections of the matrix, or <a href="gloss.html#slice">slices</a>. To access a row of values:</p>
+<p>An index like <code>(5, 6)</code> selects a single element of an array, but we can also access sections of the matrix, or <a href="reference.html#slice">slices</a>. To access a row of values:</p>
 <p><img src="fig/matrix-row.svg" style="height:350px" alt="Accessing a single value"/></p>
 <p>we can do:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">M(<span class="fl">5</span>, :)</code></pre>
@@ -213,7 +213,7 @@ age = age - <span class="fl">20</span></code></pre>
    28   38   39
    45   19   18
 </code></pre>
-<p>We don’t have to take all the values in the slice—if we provide a <a href="gloss.html#stride">stride</a>. Let’s say we want to start with row <code>2</code>, and subsequently select every third row:</p>
+<p>We don’t have to take all the values in the slice—if we provide a <a href="reference.html#stride">stride</a>. Let’s say we want to start with row <code>2</code>, and subsequently select every third row:</p>
 <p><img src="fig/matrix-strided-rows.svg" style="height:350px" alt="Accessing strided columns"/></p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">M(<span class="fl">2</span>:<span class="fl">3</span>:end, :)</code></pre>
 <pre class="output"><code>ans =
@@ -235,12 +235,12 @@ age = age - <span class="fl">20</span></code></pre>
 <h2><span class="glyphicon glyphicon-pencil"></span>Slicing</h2>
 </div>
 <div class="panel-body">
-<p>A subsection of an array is called a <a href="../../gloss.html#slice">slice</a>. We can take slices of character strings as well:</p>
+<p>A subsection of an array is called a <a href="reference.html#slice">slice</a>. We can take slices of character strings as well:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">element = <span class="st">&#39;oxygen&#39;</span>;
 disp([<span class="st">&#39;first three characters: &#39;</span>, element(<span class="fl">1</span>:<span class="fl">3</span>)])
 disp([<span class="st">&#39;last three characters: &#39;</span>, element(<span class="fl">4</span>:<span class="fl">6</span>)])</code></pre>
 <pre class="output"><code>first three characters: oxy
-last three characters: gen</code></pre>
+last three characters: gen   </code></pre>
 <ol style="list-style-type: decimal">
 <li><p>What is the value of <code>element(4:end)</code>? What about <code>element(1:2:end)</code>? Or <code>element(2:end - 1)</code>?</p></li>
 <li><p>For any size array, Matlab allows us to index with a single colon operator (<code>:</code>). This can have surprising effects. For instance, compare <code>element</code> with <code>element(:)</code>. What is <code>size(element)</code> versus <code>size(element(:))</code>? Finally, try using the single colon on the matrix <code>M</code> above: <code>M(:)</code>. What seems to be happening when we use the single colon operator for slicing?</p></li>

--- a/01-intro.md
+++ b/01-intro.md
@@ -17,7 +17,7 @@ minutes: 30
 We are studying inflammation in patients who have been given a new treatment for arthritis,
 and need to analyze the first dozen data sets.
 The data sets are stored in
-[Comma Separated Values (CSV)](gloss.html#comma-separated-values) format:
+[Comma Separated Values (CSV)](reference.html#comma-separated-values) format:
 each row holds information for a single patient,
 and the columns represent successive days.
 The first few rows of our first file,
@@ -42,17 +42,17 @@ To do all that, we'll have to learn a little bit about programming.
 We have a dozen datasets that need analysis, stored as `.csv` files -
 but MATLAB doesn't know about these files yet.
 The first thing we need to do is set MATLAB's
-[path](gloss.html#matlab-path)
-to include the directory containing the files. The MATLAB path is a list of directories 
+[path](reference.html#matlab-path)
+to include the directory containing the files. The MATLAB path is a list of directories
 on your computer that MATLAB knows about.
 To do this,
 we go to the `Home` tab,
 click on `Set Path`,
 and then on `Add with Subfolders...`.
 We navigate to the directory containing our files and
-add it to the path to tell MATLAB where to look for our files. When you refer 
-to a file (either code or data), MATLAB will search all the directories in the path 
-to find it. Alternatively, for data files, we can also provide the relative or 
+add it to the path to tell MATLAB where to look for our files. When you refer
+to a file (either code or data), MATLAB will search all the directories in the path
+to find it. Alternatively, for data files, we can also provide the relative or
 absolute file path.
 
 Before we can start programming, we need to know a little about the MATLAB interface.
@@ -102,19 +102,19 @@ csvread('inflammation-01.csv');
 ~~~
 
 The expression `csvread(...)` is a
-[function call](gloss.html#function-call).
-Functions generally need [parameters](gloss.html#parameter)
+[function call](reference.html#function-call).
+Functions generally need [parameters](reference.html#parameter)
 to run.
 In the case of the `csvread` function, we need to provide a single
 parameter: the name of the file we want to read data from. This
 parameter needs to be a character string or
-[string](gloss.html#string), so we put it in quotes.
+[string](reference.html#string), so we put it in quotes.
 
 Our call to `csvread` read our file, and printed the data inside
 to the screen. And adding a semicolon rendered it even less useful---
 we have no way to modify those values
 or compute with them. To do that, we need to assign the array to a
-[variable](gloss.html#variable).
+[variable](reference.html#variable).
 
 ~~~ {.matlab}
 patient_data = csvread('inflammation-01.csv');
@@ -250,7 +250,7 @@ To do that, simply type `clear all`.
 
 > ## Predicting Variable Values {.challenge}
 > 1.  Predict what variables refer to what values after each statement in the following program:
-> 
+>
 > ~~~ {.matlab}
 > mass = 47.5
 > age = 122
@@ -259,7 +259,7 @@ To do that, simply type `clear all`.
 > ~~~
 
 Now that our data is in memory, we can start doing things with it.
-First, let's find out its size or [shape](gloss.html#shape):
+First, let's find out its size or [shape](reference.html#shape):
 
 ~~~ {.matlab}
 size(patient_data)
@@ -336,7 +336,7 @@ We want to access a single value from the matrix:
 <img src="fig/matrix-single-element.svg" style="height:350px" alt="Accessing a single value"/>
 
 To do that, we must provide
-its [index](gloss.html#index) in brackets:
+its [index](reference.html#index) in brackets:
 
 ~~~ {.matlab}
 M(5, 6)
@@ -350,7 +350,7 @@ Indices are provided as (row, column). So the index `(5, 6)` selects the element
 on the fifth row and sixth column.
 
 An index like `(5, 6)` selects a single element of
-an array, but we can also access sections of the matrix, or [slices](gloss.html#slice).
+an array, but we can also access sections of the matrix, or [slices](reference.html#slice).
 To access a row of values:
 
 <img src="fig/matrix-row.svg" style="height:350px" alt="Accessing a single value"/>
@@ -431,7 +431,7 @@ ans =
 ~~~
 
 We don't have to take all the values in the slice---if we provide
-a [stride](gloss.html#stride). Let's say we want to start with row `2`,
+a [stride](reference.html#stride). Let's say we want to start with row `2`,
 and subsequently select every third row:
 
 <img src="fig/matrix-strided-rows.svg" style="height:350px" alt="Accessing strided columns"/>
@@ -467,22 +467,22 @@ ans =
 ~~~
 
 > ## Slicing {.challenge}
-> 
-> A subsection of an array is called a [slice](../../gloss.html#slice). We can take slices of character strings as well:
-> 
+>
+> A subsection of an array is called a [slice](reference.html#slice). We can take slices of character strings as well:
+>
 > ~~~ {.matlab}
 > element = 'oxygen';
 > disp(['first three characters: ', element(1:3)])
 > disp(['last three characters: ', element(4:6)])
 > ~~~
-> 
+>
 > ~~~ {.output}
 > first three characters: oxy
-> last three characters: gen
+> last three characters: gen   
 > ~~~
-> 
-> 1. What is the value of `element(4:end)`? What about `element(1:2:end)`? Or `element(2:end - 1)`? 
-> 
+>
+> 1. What is the value of `element(4:end)`? What about `element(1:2:end)`? Or `element(2:end - 1)`?
+>
 > 1. For any size array, Matlab allows us to index with a single colon operator (`:`).
 > This can have surprising effects.
 > For instance, compare `element` with `element(:)`. What is `size(element)` versus `size(element(:))`?

--- a/02-scripts.html
+++ b/02-scripts.html
@@ -28,13 +28,17 @@
         <div class="col-md-10 col-md-offset-1">
           <h1 class="title">Programming with MATLAB</h1>
           <h2 class="subtitle">Writing MATLAB Scripts</h2>
-<blockquote>
-<h2>Learning Objectives</h2>
+<div id="learning-objectives" class="objectives panel panel-warning">
+<div class="panel-heading">
+<h2><span class="glyphicon glyphicon-certificate"></span>Learning Objectives</h2>
+</div>
+<div class="panel-body">
 <ul>
 <li>Learn how to write and save MATLAB scripts.</li>
 <li>Learn how to save MATLAB plots to disk.</li>
 </ul>
-</blockquote>
+</div>
+</div>
 <p>So far, we’ve typed in commands one-by-one on the command line to get MATLAB to do things for us. But what if we want to repeat our analysis? Sure, it’s only a handful of commands, and typing them in shouldn’t take us more than a few minutes. But if we forget a step or make a mistake, we’ll waste time rewriting commands. Also, we’ll quickly find ourselves doing more complex analyses, and we’ll need our results to be more easily reproducible.</p>
 <p>In addition to running MATLAB commands one-by-one on the command line, we can also write several commands in a <em>script</em>. A MATLAB script is just a text file with a <code>.m</code> extension. We’ve written commands to load data from a <code>.csv</code> file and displays some statistics about that data. Let’s put those commands in a script called <code>analyze.m</code>:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab"><span class="co">% script analyze.m</span>

--- a/02-scripts.md
+++ b/02-scripts.md
@@ -5,7 +5,7 @@ subtitle: Writing MATLAB Scripts
 minutes: 30
 ---
 
-> ## Learning Objectives
+> ## Learning Objectives {.objectives}
 > * Learn how to write and save MATLAB scripts.
 > * Learn how to save MATLAB plots to disk.
 

--- a/03-loops.html
+++ b/03-loops.html
@@ -28,15 +28,19 @@
         <div class="col-md-10 col-md-offset-1">
           <h1 class="title">Programming with MATLAB</h1>
           <h2 class="subtitle">Repeating With Loops</h2>
-<blockquote>
-<h2>Learning Objectives</h2>
+<div id="learning-objectives" class="objectives panel panel-warning">
+<div class="panel-heading">
+<h2><span class="glyphicon glyphicon-certificate"></span>Learning Objectives</h2>
+</div>
+<div class="panel-body">
 <ul>
 <li>Explain what a for loop does.</li>
 <li>Correctly write for loops that repeat simple commands.</li>
 <li>Trace changes to a loop variable as the loops runs.</li>
 <li>Use a for loop to process multiple files</li>
 </ul>
-</blockquote>
+</div>
+</div>
 <!-- FIXME: this can be worded better: -->
 
 <p>Recall that we have to do this analysis for every one of our dozen datasets. And we need a better way than typing out commands for each one, because we’ll find ourselves writing a lot of duplicate code. Remember, code that is repeated in two or more places will eventually be wrong in at least one. Also, if we make changes in the way we analyze our datasets, we have to introduce that change in every copy of our code. To avoid all of this repetition, we have to teach MATLAB to repeat our commands, and to do <em>that</em>, we have to learn how to write <em>loops</em>.</p>
@@ -148,8 +152,11 @@ aluminu
 aluminum</code></pre>
 </div>
 </div>
-<blockquote>
-<h2>Looping in Reverse .{challenge}</h2>
+<div id="looping-in-reverse" class="challenge panel panel-success">
+<div class="panel-heading">
+<h2><span class="glyphicon glyphicon-pencil"></span>Looping in Reverse</h2>
+</div>
+<div class="panel-body">
 <p>In Matlab, the colon operator (<code>:</code>) accepts a <a href="../../gloss.&gt;%20html#stride">stride</a> or skip argument between the start and stop:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">disp(<span class="fl">1</span>:<span class="fl">3</span>:<span class="fl">11</span>)</code></pre>
 <pre class="output"><code>1 4 7 10</code></pre>
@@ -164,7 +171,8 @@ m
 u
 l
 a</code></pre>
-</blockquote>
+</div>
+</div>
 <p>We now have almost everything we need to process multiple data files with our <code>analyze</code> script. You’ll notice that our data files are named <code>inflammation-01.csv</code>, <code>inflammation-02.csv</code>, etc. Let’s write a loop that tries to print the names of each one of our files:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">for idx = <span class="fl">1</span>:<span class="fl">12</span>
     file_name = sprintf(<span class="st">&#39;inflammation-%d.csv&#39;</span>, idx);
@@ -185,7 +193,7 @@ inflammation-12.csv</code></pre>
 <p>This is close, but not quite right. The <code>sprintf</code> function is useful when we want to generate MATLAB strings based on a <em>template</em>. In our case, that template is the string <code>inflammation-%d.csv</code>. <code>sprintf</code> generates a new string from our template by replacing the <code>%d</code> with the data referred to by our second argument, <code>i</code>.</p>
 <p>Again, let’s trace the execution of our loop: in the beginning of our loop, <code>i</code> starts by referring to the value 1. So, when MATLAB executes the command</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">file_name = sprintf(<span class="st">&#39;inflammation-%d.csv&#39;</span>, idx);</code></pre>
-<p>it substitutes the <code>%d</code> in the template <code>inflammation-%d.csv</code>, with the value of <code>i</code>, i.e., 1. The resulting string is <code>inflammation-1.csv</code>, which is assigned to the variable <code>file_name</code>. The <code>disp</code> command prints that string to screen. The second time around, <code>sprintf</code> generates the string <code>inflammation-2.csv, which is assigned to the variable</code>file_name<code>, and printed to screen.  And so on, till</code>i` finally refers to the value 12.</p>
+<p>it substitutes the <code>%d</code> in the template <code>inflammation-%d.csv</code>, with the value of <code>i</code>, i.e., 1. The resulting string is <code>inflammation-1.csv</code>, which is assigned to the variable <code>file_name</code>. The <code>disp</code> command prints that string to screen. The second time around, <code>sprintf</code> generates the string <code>inflammation-2.csv</code>, which is assigned to the variable <code>file_name</code>, and printed to screen. And so on, till <code>i</code> finally refers to the value 12.</p>
 <p>Notice that there’s a mistake. Our files are actually named <code>inflammation-01.csv</code>, <code>inflammation-02.csv</code>, etc. To get it right, we have to modify our template:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">for idx = <span class="fl">1</span>:<span class="fl">12</span>
     file_name = sprintf(<span class="st">&#39;inflammation-%02d.csv&#39;</span>, idx);
@@ -239,8 +247,11 @@ end</code></pre>
 <p><img src="img/02-loop_2.png" style="width:500px; height:400px"></p>
 <p><img src="img/02-loop_3.png" style="width:500px; height:400px"></p>
 <p>Sure enough, the maxima of these data sets show exactly the same ramp as the first, and their minima show the same staircase structure.</p>
-<blockquote>
-<h2>Another Way to Analyze Multiple Files .{challenge}</h2>
+<div id="another-way-to-analyze-multiple-files" class="challenge panel panel-success">
+<div class="panel-heading">
+<h2><span class="glyphicon glyphicon-pencil"></span>Another Way to Analyze Multiple Files</h2>
+</div>
+<div class="panel-body">
 <p>In cases where our file names don’t follow such a regular pattern, we might want to process all files that end with a given extension, say <code>.csv</code>. At the command line we could get this list of files by using a <a href="../../gloss.html#wildcard">wildcard</a>:</p>
 <pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">ls</span> *.csv</code></pre>
 <p>Thankfully, Matlab also has <code>ls</code>, though it returns a single long string:</p>
@@ -269,7 +280,8 @@ Columns 10 through 13
 
 &#39;inflammation-06.csv&#39;    &#39;inflammation-09.csv&#39;    &#39;inflammation-12.&gt; csv&#39;    &#39;&#39;</code></pre>
 <p>Using this trick, rewrite the <code>analyze</code> script to analyze all <code>csv</code> files in the current directory. Be careful of the empty string <code>''</code> at the end of <code>file_list</code>!</p>
-</blockquote>
+</div>
+</div>
         </div>
       </div>
       </article>

--- a/03-loops.html
+++ b/03-loops.html
@@ -77,12 +77,12 @@ end</code></pre>
 e
 a
 d</code></pre>
-<p>This improved version uses a <a href="../../gloss.html#for-loop">for loop</a> to repeat an operation—in this case, printing to the screen—once for each element in an array.</p>
+<p>This improved version uses a <a href="reference.html#for-loop">for loop</a> to repeat an operation—in this case, printing to the screen—once for each element in an array.</p>
 <p>The general form of a for loop is:</p>
 <pre><code>for variable = collection
     do things with variable
 end</code></pre>
-<p>The for loop executes the commands in the <a href="../../gloss.html#loop-body">loop body</a> for every value in the array <code>collection</code>. This value is called the <a href="../../gloss.html#loop-variable">loop variable</a>, and we can call it whatever we like. In our example, we gave it the name <code>letter</code>.</p>
+<p>The for loop executes the commands in the <a href="reference.html#loop-body">loop body</a> for every value in the array <code>collection</code>. This value is called the <a href="reference.html#loop-variable">loop variable</a>, and we can call it whatever we like. In our example, we gave it the name <code>letter</code>.</p>
 <p>We have to terminate the loop body with the <code>end</code> keyword, and we can have as many commands as we like in the loop body. But, we have to remember that they will all be repeated as many times as there are values in <code>collection</code>.</p>
 <p>Our for loop has made our code more scalable, and less fragile. There’s still one little thing about it that should bother us. For our loop to deal appropriately with shorter or longer words, we have to change the first line of our loop by hand:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">word = <span class="st">&#39;tin&#39;</span>;
@@ -157,7 +157,7 @@ aluminum</code></pre>
 <h2><span class="glyphicon glyphicon-pencil"></span>Looping in Reverse</h2>
 </div>
 <div class="panel-body">
-<p>In Matlab, the colon operator (<code>:</code>) accepts a <a href="../../gloss.&gt;%20html#stride">stride</a> or skip argument between the start and stop:</p>
+<p>In Matlab, the colon operator (<code>:</code>) accepts a <a href="reference.&gt;%20html#stride">stride</a> or skip argument between the start and stop:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">disp(<span class="fl">1</span>:<span class="fl">3</span>:<span class="fl">11</span>)</code></pre>
 <pre class="output"><code>1 4 7 10</code></pre>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">disp(<span class="fl">11</span>:-<span class="fl">3</span>:<span class="fl">1</span>)</code></pre>
@@ -252,7 +252,7 @@ end</code></pre>
 <h2><span class="glyphicon glyphicon-pencil"></span>Another Way to Analyze Multiple Files</h2>
 </div>
 <div class="panel-body">
-<p>In cases where our file names don’t follow such a regular pattern, we might want to process all files that end with a given extension, say <code>.csv</code>. At the command line we could get this list of files by using a <a href="../../gloss.html#wildcard">wildcard</a>:</p>
+<p>In cases where our file names don’t follow such a regular pattern, we might want to process all files that end with a given extension, say <code>.csv</code>. At the command line we could get this list of files by using a <a href="reference.html#wildcard">wildcard</a>:</p>
 <pre class="sourceCode bash"><code class="sourceCode bash"><span class="kw">ls</span> *.csv</code></pre>
 <p>Thankfully, Matlab also has <code>ls</code>, though it returns a single long string:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">filestr = ls(<span class="st">&#39;*.csv&#39;</span>)</code></pre>

--- a/03-loops.md
+++ b/03-loops.md
@@ -5,7 +5,7 @@ subtitle: Repeating With Loops
 minutes: 30
 ---
 
-> ## Learning Objectives
+> ## Learning Objectives {.objectives}
 > * Explain what a for loop does.
 > * Correctly write for loops that repeat simple commands.
 > * Trace changes to a loop variable as the loops runs.
@@ -247,7 +247,7 @@ u
 > aluminum
 > ~~~
 
-> ## Looping in Reverse .{challenge}
+> ## Looping in Reverse {.challenge}
 > 
 > In Matlab, the colon operator (`:`) accepts a
 > [stride](../../gloss.> html#stride)
@@ -336,7 +336,7 @@ with the value of `i`, i.e., 1.
 The resulting string is `inflammation-1.csv`,
 which is assigned to the variable `file_name`.
 The `disp` command prints that string to screen.
-The second time around, `sprintf` generates the string `inflammation-2.csv, which is assigned to the variable `file_name`,
+The second time around, `sprintf` generates the string `inflammation-2.csv`, which is assigned to the variable `file_name`,
 and printed to screen. 
 And so on, till `i` finally refers to the value 12.
 
@@ -421,7 +421,7 @@ Sure enough, the maxima of these data sets show exactly
 the same ramp as the first,
 and their minima show the same staircase structure.
 
-> ## Another Way to Analyze Multiple Files .{challenge}
+> ## Another Way to Analyze Multiple Files {.challenge}
 > 
 > In cases where our file names don't follow such a regular pattern,
 > we might want to process all files that end with a given extension,

--- a/03-loops.md
+++ b/03-loops.md
@@ -88,8 +88,8 @@ a
 d
 ~~~
 
-This improved version uses a [for loop](../../gloss.html#for-loop) to
-repeat an operation---in this case, printing to the screen---once for 
+This improved version uses a [for loop](reference.html#for-loop) to
+repeat an operation---in this case, printing to the screen---once for
 each element in an array.
 
 The general form of a for loop is:
@@ -101,9 +101,9 @@ end
 ~~~
 
 The for loop executes the commands in the
-[loop body](../../gloss.html#loop-body)
+[loop body](reference.html#loop-body)
 for every value in the array `collection`.
-This value is called the [loop variable](../../gloss.html#loop-variable),
+This value is called the [loop variable](reference.html#loop-variable),
 and we can call it whatever we like.
 In our example, we gave it the name `letter`.
 
@@ -213,29 +213,29 @@ u
 ~~~
 
 > ## Performing Exponentiation {.challenge}
-> 
+>
 > MATLAB uses the caret (`^`) to perform exponentiation:
-> 
+>
 > ~~~{.matlab}
 > disp(5^3)
 > ~~~
-> 
+>
 > ~~~{.output}
 > 125
 > ~~~
-> 
+>
 > You can also use a loop to perform exponentiation.
 > Remember that `b^x` is just
 > `b*b*b*`... `x` times.
-> 
+>
 > Let a variable `b` be the base of the number and `x` the exponent.
 > Write a loop to compute `b^x`.
 > Check your result for `b = 4` and `x = 5`.
 
 > ## Incrementing with Loops {.challenge}
-> 
+>
 > Write a loop that spells the word "aluminum," adding one letter at a time:
-> 
+>
 > ~~~{.output}
 > a
 > al
@@ -248,31 +248,31 @@ u
 > ~~~
 
 > ## Looping in Reverse {.challenge}
-> 
+>
 > In Matlab, the colon operator (`:`) accepts a
-> [stride](../../gloss.> html#stride)
+> [stride](reference.> html#stride)
 > or skip argument between the start and stop:
-> 
+>
 > ~~~{.matlab}
 > disp(1:3:11)
 > ~~~
-> 
+>
 > ~~~{.output}
 > 1 4 7 10
 > ~~~
-> 
+>
 > ~~~{.matlab}
 > disp(11:-3:1)
 > ~~~
-> 
+>
 > ~~~{.output}
 > 11 8 5 2
 > ~~~
-> 
+>
 > Using this,
 > write a loop to print the letters of "aluminum"
 > in reverse order, one letter per line.
-> 
+>
 > ~~~{.output}
 > m
 > u
@@ -337,7 +337,7 @@ The resulting string is `inflammation-1.csv`,
 which is assigned to the variable `file_name`.
 The `disp` command prints that string to screen.
 The second time around, `sprintf` generates the string `inflammation-2.csv`, which is assigned to the variable `file_name`,
-and printed to screen. 
+and printed to screen.
 And so on, till `i` finally refers to the value 12.
 
 Notice that there's a mistake.
@@ -422,58 +422,58 @@ the same ramp as the first,
 and their minima show the same staircase structure.
 
 > ## Another Way to Analyze Multiple Files {.challenge}
-> 
+>
 > In cases where our file names don't follow such a regular pattern,
 > we might want to process all files that end with a given extension,
 > say `.csv`.
 > At the command line we could get this list of files by using a
-> [wildcard](../../gloss.html#wildcard):
-> 
+> [wildcard](reference.html#wildcard):
+>
 > ~~~{.bash}
 > ls *.csv
 > ~~~
-> 
+>
 > Thankfully, Matlab also has `ls`, though it returns a single long string:
-> 
+>
 > ~~~{.matlab}
 > filestr = ls('*.csv')
 > ~~~
-> 
+>
 > ~~~{.output}
 > inflammation-01.csv inflammation-04.csv inflammation-07.csv inflammation-10.csv
 > inflammation-02.csv inflammation-05.csv inflammation-08.csv inflammation-11.csv
 > inflammation-03.csv inflammation-06.csv inflammation-09.csv inflammation-12.csv
 > ~~~
-> 
+>
 > To turn this string into an array we can loop over (actually, a
 > [Cell Array](http://www.mathworks.com/help/matlab/cell-arrays.html)),
 > we need to "split" the string at each occurrence of whitespace:
-> 
+>
 > ~~~{.matlab}
 > file_string = ls('*.csv');
 > file_list = strsplit(file_string)
 > ~~~
-> 
+>
 > ~~~{.output}
 > file_list =
-> 
+>
 > Columns 1 through 3
 >
 > 'inflammation-01.csv'    'inflammation-04.csv'    'inflammation-07.csv'
-> 
+>
 > Columns 4 through 6
-> 
+>
 > 'inflammation-10.csv'    'inflammation-02.csv'    'inflammation-05.csv'
-> 
+>
 > Columns 7 through 9
-> 
+>
 > 'inflammation-08.csv'    'inflammation-11.csv'    'inflammation-03.csv'
-> 
+>
 > Columns 10 through 13
-> 
+>
 > 'inflammation-06.csv'    'inflammation-09.csv'    'inflammation-12.> csv'    ''
 > ~~~
-> 
+>
 > Using this trick,
 > rewrite the `analyze` script to analyze all `csv` files in
 > the current directory.

--- a/04-func.html
+++ b/04-func.html
@@ -79,7 +79,7 @@ end</code></pre>
 <p>Again, we can call this function like any other:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">kelvin_to_celsius(<span class="fl">0.0</span>)</code></pre>
 <pre class="output"><code>ans = -273.15</code></pre>
-<p>What about converting Fahrenheit to Celsius? We could write out the formula, but we don’t need to. Instead, we can <a href="gloss.html#function-composition">compose</a> the two functions we have already created:</p>
+<p>What about converting Fahrenheit to Celsius? We could write out the formula, but we don’t need to. Instead, we can <a href="reference.html#function-composition">compose</a> the two functions we have already created:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab"><span class="co">% file fahr_to_celsius.m</span>
 
 function ctemp = fahr_to_celsius(ftemp)
@@ -141,7 +141,7 @@ centered = center(data(:), <span class="fl">0</span>)</code></pre>
 <p>That seems almost right: the original mean was about 6.1, so the lower bound from zero is now about -6.1. The mean of the centered data isn’t quite zero–we’ll explore why not in the challenges–but it’s pretty close. We can even go further and check that the standard deviation hasn’t changed:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">std(data(:)) - std(centered)</code></pre>
 <pre class="output"><code>5.3291e-15</code></pre>
-<p>The difference is very small. It’s still possible that our function is wrong, but it seems unlikely enough that we should probably get back to doing our analysis. We have one more task first, though: we should write some <a href="gloss.html#documentation">documentation</a> for our function to remind ourselves later what it’s for and how to use it.</p>
+<p>The difference is very small. It’s still possible that our function is wrong, but it seems unlikely enough that we should probably get back to doing our analysis. We have one more task first, though: we should write some <a href="reference.html#documentation">documentation</a> for our function to remind ourselves later what it’s for and how to use it.</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">function out = center(data, desired)
     <span class="co">%   Center data around a desired value.</span>
     <span class="co">%</span>

--- a/04-func.html
+++ b/04-func.html
@@ -91,8 +91,11 @@ end</code></pre>
 <p>we get, as expected:</p>
 <pre><code>ans = -273.15</code></pre>
 <p>This is our first taste of how larger programs are built: we define basic operations, then combine them in ever-large chunks to get the effect we want. Real-life functions will usually be larger than the ones shown here—typically half a dozen to a few dozen lines—but they shouldn’t ever be much longer than that, or the next person who reads it won’t be able to understand what’s going on.</p>
-<blockquote>
-<h2>Concatenating in a function</h2>
+<div id="concatenating-in-a-function" class="challenge panel panel-success">
+<div class="panel-heading">
+<h2><span class="glyphicon glyphicon-pencil"></span>Concatenating in a function</h2>
+</div>
+<div class="panel-body">
 <ol style="list-style-type: decimal">
 <li>In Matlab, we concatenate strings by putting them into an array or using the <code>strcat</code> function:</li>
 </ol>
@@ -104,7 +107,8 @@ end</code></pre>
 <li>If the variable <code>s</code> refers to a string, then <code>s(1)</code> is the string’s first character and <code>s(end)</code> is its last. Write a function called <code>outer</code> that returns a string made up of just the first and last characters of its input:</li>
 </ol>
 <p><sub>~</sub> {.matlab} disp(outer(‘helium’)) <sub>~</sub> <sub>~</sub> {.output} hm <sub>~</sub></p>
-</blockquote>
+</div>
+</div>
 <p>Let’s take a closer look at what happens when we call <code>fahr_to_celcius(32.0)</code>. To make things clearer, we’ll start by putting the initial value 32.0 in a variable and store the final result in one as well:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">original = <span class="fl">32.0</span>;
 final = fahr_to_celcius(original);</code></pre>
@@ -156,14 +160,18 @@ end</code></pre>
 
 Returns a new array containing the values in
 DATA centered around the value.</code></pre>
-<blockquote>
-<h2>Testing a function</h2>
+<div id="testing-a-function" class="challenge panel panel-success">
+<div class="panel-heading">
+<h2><span class="glyphicon glyphicon-pencil"></span>Testing a function</h2>
+</div>
+<div class="panel-body">
 <ol style="list-style-type: decimal">
 <li><p>Write a function called <code>rescale</code> that takes an array as input and returns an array of the same shape with its values scaled to lie in the range 0.0 to 1.0. (If L and H are the lowest and highest values in the input array, respectively, then the function should map a value v to (v - L)/(H - L).) Be sure to give the function a comment block explaining its use.</p></li>
 <li><p>Run <code>help linspace</code> to see how to use this function to generate regularly-spaced values. Use arrays like this to test your <code>rescale</code> function.</p></li>
 <li><p>Write a function <code>run_analysis</code> that accepts a filename as parameter, and displays the three graphs produced in the previous lesson, i.e., <code>run_analysis('inflammation-01.csv')</code> should produce the corresponding graphs for the first data set. Be sure to give your function help text.</p></li>
 </ol>
-</blockquote>
+</div>
+</div>
 <p>We have now solved our original problem: we can analyze any number of data files with a single command. More importantly, we have met two of the most important ideas in programming:</p>
 <ol style="list-style-type: decimal">
 <li><p>Use arrays to store related values, and loops to repeat operations on them.</p></li>

--- a/04-func.md
+++ b/04-func.md
@@ -111,7 +111,7 @@ ans = -273.15
 
 What about converting Fahrenheit to Celsius?
 We could write out the formula, but we don't need to.
-Instead, we can [compose](gloss.html#function-composition) the two
+Instead, we can [compose](reference.html#function-composition) the two
 functions we have already created:
 
 ~~~ {.matlab}
@@ -144,38 +144,38 @@ they shouldn't ever be much longer than that,
 or the next person who reads it won't be able to understand what's going on.
 
 > ## Concatenating in a function {.challenge}
-> 
+>
 > 1. In Matlab, we concatenate strings by putting them into an array or using the
 >    `strcat` function:
-> 
+>
 >    ~~~ {.matlab}
 >    disp(['abra', 'cad', 'abra'])
 >    ~~~
 >    ~~~ {.output}
->    abracadabra 
+>    abracadabra
 >    ~~~
-> 
+>
 >    ~~~ {.matlab}
 >    disp(strcat('a', 'b'))
 >    ~~~
 >    ~~~ {.output}
 >    ab
 >    ~~~
-> 
+>
 >    Write a function called `fence` that takes two parameters, `original` and
 >    `wrapper` and appends `wrapper` before and after `original`:
-> 
+>
 >    ~~~ {.matlab}
 >    disp(fence('name', '*'))
 >    ~~~
 >    ~~~ {.output}
 >    *name*
 >    ~~~
-> 
+>
 > 1. If the variable `s` refers to a string, then `s(1)` is the string's first
 >    character and `s(end)` is its last. Write a function called `outer` that returns
->    a string made up of just the first and last characters of its input: 
-> 
+>    a string made up of just the first and last characters of its input:
+>
 >    ~~~ {.matlab}
 >    disp(outer('helium'))
 >    ~~~
@@ -283,7 +283,7 @@ std(data(:)) - std(centered)
 The difference is very small. It's still possible that our function
 is wrong, but it seems unlikely enough that we should probably
 get back to doing our analysis. We have one more task first, though:
-we should write some [documentation](gloss.html#documentation)
+we should write some [documentation](reference.html#documentation)
 for our function to remind ourselves later what it's for and
 how to use it.
 
@@ -318,16 +318,16 @@ DATA centered around the value.
 ~~~
 
 > ## Testing a function {.challenge}
-> 
+>
 > 1. Write a function called `rescale` that takes an array as input and returns an
 >    array of the same shape with its values scaled to lie in the range 0.0 to 1.0.
 >    (If L and H are the lowest and highest values in the input array, respectively,
 >    then the function should map a value v to (v - L)/(H - L).) Be sure to give the
 >    function a comment block explaining its use.
-> 
+>
 > 1. Run `help linspace` to see how to use this function to generate
 >    regularly-spaced values. Use arrays like this to test your `rescale` function.
-> 
+>
 > 1. Write a function `run_analysis` that accepts a filename
 >    as parameter, and displays the three graphs produced in the
 >    previous lesson, i.e., `run_analysis('inflammation-01.csv')`
@@ -335,7 +335,7 @@ DATA centered around the value.
 >    data set. Be sure to give your function help text.
 
 
-We have now solved our original problem: we can analyze 
+We have now solved our original problem: we can analyze
 any number of data files with a single command.
 More importantly, we have met two of the most important
 ideas in programming:

--- a/04-func.md
+++ b/04-func.md
@@ -143,7 +143,7 @@ here---typically half a dozen to a few dozen lines---but
 they shouldn't ever be much longer than that,
 or the next person who reads it won't be able to understand what's going on.
 
-> ## Concatenating in a function {.challenges}
+> ## Concatenating in a function {.challenge}
 > 
 > 1. In Matlab, we concatenate strings by putting them into an array or using the
 >    `strcat` function:
@@ -317,7 +317,7 @@ Returns a new array containing the values in
 DATA centered around the value.
 ~~~
 
-> ## Testing a function {.challenges}
+> ## Testing a function {.challenge}
 > 
 > 1. Write a function called `rescale` that takes an array as input and returns an
 >    array of the same shape with its values scaled to lie in the range 0.0 to 1.0.

--- a/05-cond.html
+++ b/05-cond.html
@@ -93,8 +93,11 @@ end</code></pre>
 end</code></pre>
 <pre class="output"><code>at least one part is true</code></pre>
 <p>In this case, “either” means “either or both”, not “either one or the other but not both”.</p>
-<blockquote>
-<h2>True and false statements</h2>
+<div id="true-and-false-statements" class="challenge panel panel-success">
+<div class="panel-heading">
+<h2><span class="glyphicon glyphicon-pencil"></span>True and false statements</h2>
+</div>
+<div class="panel-body">
 <ol style="list-style-type: decimal">
 <li><p><code>1</code> and <code>0</code> aren’t the only values in MATLAB that are true or false. In fact, <em>any</em> value can be used in an <code>if</code> or <code>elseif</code>. After reading and running the code below, explain what the rule is for which values that are considered true and which are considered false.</p></li>
 <li><p><sub>~</sub> if disp(‘empty string is true’) end <sub>~</sub></p></li>
@@ -112,7 +115,8 @@ end</code></pre>
 <ol start="2" style="list-style-type: decimal">
 <li>Write a function called <code>near</code> that returns <code>1</code> when its first parameter is within 10% of its second and <code>0</code> otherwise. Compare your implementation with your partner’s: do you return the same answer for all possible pairs of numbers?</li>
 </ol>
-</blockquote>
+</div>
+</div>
 <p>Another thing to realize is that <code>if</code> statements can be combined with loops just as easily as they can be combined with functions. For example, if we want to sum the positive numbers in a list, we can write this:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">numbers = [-<span class="fl">5</span>, <span class="fl">3</span>, <span class="fl">2</span>, -<span class="fl">1</span>, <span class="fl">9</span>, <span class="fl">6</span>];
 total = <span class="fl">0</span>;
@@ -153,8 +157,11 @@ ca
 ce
 da
 de</code></pre>
-<blockquote>
-<h2>Nesting</h2>
+<div id="nesting" class="challenge panel panel-success">
+<div class="panel-heading">
+<h2><span class="glyphicon glyphicon-pencil"></span>Nesting</h2>
+</div>
+<div class="panel-body">
 <ol style="list-style-type: decimal">
 <li><p>Will changing the order of nesting in the above loop change the output? Why? Write down the output you might expect from changing the order of the loops, then rewrite the code to test your hypothesis.</p></li>
 <li><p>MATLAB (and most other languges in the C family) provides <a href="gloss.html#in-place-operator">in-place operators</a> that work like this:</p></li>
@@ -163,7 +170,8 @@ de</code></pre>
 x += 1;
 x *= 3;</code></pre>
 <p>Rewrite the code that sums the positive and negative values in an array using these in-place operators. Do you think that the result is more or less readable than the original?</p>
-</blockquote>
+</div>
+</div>
 <p>The last step is to turn our data into something we can see and make sense of. As in previous lessons, we need to first get the data in memory:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">patient_data = csvread(<span class="st">&#39;inflammation-01.csv&#39;</span>);</code></pre>
 <p>The heatmap from lesson 1 is useful, but fairly hard to read:</p>
@@ -279,12 +287,16 @@ axis equal</code></pre>
 <div>
 <img src="img/04-cond_4.png" style="height:350px">
 </div>
-<blockquote>
-<h2>Design choice</h2>
+<div id="design-choice" class="challenge panel panel-success">
+<div class="panel-heading">
+<h2><span class="glyphicon glyphicon-pencil"></span>Design choice</h2>
+</div>
+<div class="panel-body">
 <ol style="list-style-type: decimal">
 <li>Why does the <code>make_heatmap</code> function return an array instead of displaying it immediately? Do you think this is a good design choice?</li>
 </ol>
-</blockquote>
+</div>
+</div>
 <p>Before we are ready to publish our <code>make_heatmap</code> function, we need to be sure of its correctness. To do that, we need to learn how to <em>test</em> our code, and that will be the subject of our next lesson.</p>
         </div>
       </div>

--- a/05-cond.html
+++ b/05-cond.html
@@ -41,7 +41,7 @@
 </div>
 </div>
 <p>Our previous lessons have shown us how to manipulate data, define our own functions, and repeat things. However, the programs we have written so far always do the same things, regardless of what data they’re given. We want programs to make choices based on the values they are manipulating.</p>
-<p>The tool that MATLAB gives us for doing this is called a <a href="gloss.html#conditional-statement">conditional statement</a>, and it looks like this:</p>
+<p>The tool that MATLAB gives us for doing this is called a <a href="reference.html#conditional-statement">conditional statement</a>, and it looks like this:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">num = <span class="fl">37</span>;
 
 if num &gt; <span class="fl">100</span>
@@ -164,7 +164,7 @@ de</code></pre>
 <div class="panel-body">
 <ol style="list-style-type: decimal">
 <li><p>Will changing the order of nesting in the above loop change the output? Why? Write down the output you might expect from changing the order of the loops, then rewrite the code to test your hypothesis.</p></li>
-<li><p>MATLAB (and most other languges in the C family) provides <a href="gloss.html#in-place-operator">in-place operators</a> that work like this:</p></li>
+<li><p>MATLAB (and most other languges in the C family) provides <a href="reference.html#in-place-operator">in-place operators</a> that work like this:</p></li>
 </ol>
 <pre><code>x = 1;
 x += 1;
@@ -209,7 +209,7 @@ colorbar();</code></pre>
 </ol>
 <p>Here’s how we can improve it:</p>
 <ol style="list-style-type: decimal">
-<li><p>We can pick better colors, and use a <a href="gloss.html#colormap">colormap</a></p></li>
+<li><p>We can pick better colors, and use a <a href="reference.html#colormap">colormap</a></p></li>
 <li><p>Instead of checking if values are exactly equal to the mean, we can check if they are close to it.</p></li>
 <li><p>We can calculate the mean once, before the loop, and use that value over and over. The cost of computing the mean is much more than retrieving its value from memory.</p></li>
 </ol>

--- a/05-cond.md
+++ b/05-cond.md
@@ -7,7 +7,7 @@ minutes: 30
 
 > ## Learning Objectives {.objectives}
 > * Learn about if, elseif, and else
-> * Learn to test equality, AND, and OR conditions 
+> * Learn to test equality, AND, and OR conditions
 > * Learn to nest loops
 
 
@@ -19,7 +19,7 @@ We want programs to make choices based on the values
 they are manipulating.
 
 The tool that MATLAB gives us for doing this is called
-a [conditional statement](gloss.html#conditional-statement),
+a [conditional statement](reference.html#conditional-statement),
 and it looks like this:
 
 ~~~ {.matlab}
@@ -261,7 +261,7 @@ de
 > your hypothesis.
 >
 > 2. MATLAB (and most other languges in the C family) provides
-> [in-place operators](gloss.html#in-place-operator) that
+> [in-place operators](reference.html#in-place-operator) that
 > work like this:
 >
 > ~~~
@@ -334,7 +334,7 @@ wrong with it:
 Here's how we can improve it:
 
 1. We can pick better colors, and use a
-[colormap](gloss.html#colormap)
+[colormap](reference.html#colormap)
 
 2. Instead of checking if values are exactly equal to the mean,
 we can check if they are close to it.
@@ -447,7 +447,7 @@ axis equal
 </div>
 
 > ##  Design choice {.challenge}
-> 
+>
 > 1. Why does the `make_heatmap` function return an array instead
 > of displaying it immediately? Do you think this is a good
 > design choice?

--- a/05-cond.md
+++ b/05-cond.md
@@ -124,7 +124,7 @@ at least one part is true
 In this case, "either" means "either or both", not
 "either one or the other but not both".
 
-> ## True and false statements {.challenges}
+> ## True and false statements {.challenge}
 > 1. `1` and `0` aren't the only values
    in MATLAB that are true or false. In fact, *any* value
    can be used in an `if` or `elseif`. After reading and
@@ -253,7 +253,7 @@ da
 de
 ~~~
 
-> ## Nesting {.challenges}
+> ## Nesting {.challenge}
 >
 > 1. Will changing the order of nesting in the above loop change
 > the output? Why? Write down the output you might expect from
@@ -446,7 +446,7 @@ axis equal
 <img src="img/04-cond_4.png" style="height:350px">
 </div>
 
-> ##  Design choice {.challenges}
+> ##  Design choice {.challenge}
 > 
 > 1. Why does the `make_heatmap` function return an array instead
 > of displaying it immediately? Do you think this is a good

--- a/06-defensive.html
+++ b/06-defensive.html
@@ -113,12 +113,16 @@ end</code></pre>
 <p>But assertions aren’t just about catching errors: they also help people understand programs. Each assertion gives the person reading the program a chance to check (consciously or otherwise) that their understanding matches what the code is doing.</p>
 <p>Most good programmers follow two rules when adding assertions to their code. The first is, “<a href="rules.html#fail-early-fail-often">fail early, fail often</a>”. The greater the distance between when and where an error occurs and when it’s noticed, the harder the error will be to debug, so good code catches mistakes as early as possible.</p>
 <p>The second rule is, “<a href="rules.html#turn-bugs-into-assertions-or-tests">turn bugs into assertions or tests</a>”. If you made a mistake in a piece of code, the odds are good that you have made other mistakes nearby, or will make the same mistake (or a related one) the next time you change it. Writing assertions to check that you haven’t <a href="gloss.html#regression">regressed</a> (i.e., haven’t re-introduced an old problem) can save a lot of time in the long run, and helps to warn people who are reading the code (including your future self) that this bit is tricky.</p>
-<blockquote>
-<h2>Finding conditions</h2>
+<div id="finding-conditions" class="challenge panel panel-success">
+<div class="panel-heading">
+<h2><span class="glyphicon glyphicon-pencil"></span>Finding conditions</h2>
+</div>
+<div class="panel-body">
 <ol style="list-style-type: decimal">
 <li>Suppose you are writing a function called <code>average</code> that calculates the average of the numbers in a list. What pre-conditions and post-conditions would you write for it? Compare your answer to your neighbor’s: can you think of a function that will past your tests but not hers or vice versa?</li>
 </ol>
-</blockquote>
+</div>
+</div>
 <p>An assertion checks that something is true at a particular point in the program. The next step is to check the overall behavior of a piece of code, i.e., to make sure that it produces the right output when it’s given a particular input. For example, suppose we need to find where two or more time series overlap. The range of each time series is represented as a pair of numbers, which are the time the interval started and ended. The output is the largest range that they all include:</p>
 <p><img src="fig/matlab-overlapping-ranges.png" alt="Overlapping Ranges" /></p>
 <p>Most novice programmers would solve this problem like this:</p>
@@ -147,7 +151,7 @@ assert(range_overlap([<span class="fl">0.0</span>, <span class="fl">1.0</span>],
 <pre class="sourceCode matlab"><code class="sourceCode matlab">test_range_overlap</code></pre>
 <pre class="error"><code>Undefined function &#39;range_overlap&#39; for input arguments of type &#39;double&#39;.
 
-Error in test_range_overlap (line 3)
+Error in test_range_overlap (line 6)
 assert(range_overlap([0, 1.0]) == [0, 1.0]);</code></pre>
 <p>The error is actually reassuring: we haven’t written <code>range_overlap</code> yet, so if the tests passed, it would be a sign that someone else had and that we were accidentally using their function.</p>
 <p>And as a bonus of writing these tests, we’ve implicitly defined what our input and output look like: we expect a list of pairs as input, and produce a single pair as output.</p>

--- a/06-defensive.html
+++ b/06-defensive.html
@@ -51,7 +51,7 @@
 <li>make sure we know what “correct” actually means.</li>
 </ul>
 <p>The good news is, doing these things will speed up our programming, not slow it down.</p>
-<p>The first step toward getting the right answers from our programs is to assume that mistakes <em>will</em> happen and to guard against them. This is called <a href="gloss.html#defensive-programming">defensive programming</a>, and the most common way to do it is to add <a href="gloss.html#assertion">assertions</a> to our code so that it checks itself as it runs. An assertion is simply a statement that something must be true at a certain point in a program. When MATLAB sees one, it checks the assertion’s condition. If it’s true, MATLAB does nothing, but if it’s false, MATLAB halts the program immediately and prints an error message. For example, this piece of code halts as soon as the loop encounters a value that isn’t positive:</p>
+<p>The first step toward getting the right answers from our programs is to assume that mistakes <em>will</em> happen and to guard against them. This is called <a href="reference.html#defensive-programming">defensive programming</a>, and the most common way to do it is to add <a href="reference.html#assertion">assertions</a> to our code so that it checks itself as it runs. An assertion is simply a statement that something must be true at a certain point in a program. When MATLAB sees one, it checks the assertion’s condition. If it’s true, MATLAB does nothing, but if it’s false, MATLAB halts the program immediately and prints an error message. For example, this piece of code halts as soon as the loop encounters a value that isn’t positive:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">numbers = [<span class="fl">1.5</span>, <span class="fl">2.3</span>, <span class="fl">0.7</span>, -<span class="fl">0.001</span>, <span class="fl">4.4</span>];
 total = <span class="fl">0</span>;
 
@@ -62,7 +62,7 @@ end</code></pre>
 <pre class="output"><code>error: assert (n &gt;= 0) failed</code></pre>
 <p>Programs like the Firefox browser are full of assertions: 10-20% of the code they contain are there to check that the other 80-90% are working correctly. Broadly speaking, assertions fall into three categories:</p>
 <ul>
-<li>A <a href="gloss.html#precondition">precondition</a> is something that must be true at the start of a function in order for it to work correctly.</li>
+<li>A <a href="reference.html#precondition">precondition</a> is something that must be true at the start of a function in order for it to work correctly.</li>
 <li>A postcondition is something that the function guarantees is true when it finishes.</li>
 <li>An invariant is something that is always true at a particular point inside a piece of code.</li>
 </ul>
@@ -70,7 +70,7 @@ end</code></pre>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">function normalized = normalize_rectangle(rect)
     <span class="co">% Normalizes a rectangle so that it is at the origin</span>
     <span class="co">% and 1.0 units long on its longest axis:</span>
-    
+
     x0 = rect(<span class="fl">1</span>);
     y0 = rect(<span class="fl">2</span>);
     x1 = rect(<span class="fl">3</span>);
@@ -82,7 +82,7 @@ end</code></pre>
 
     dx = x1 - x0;
     dy = y1 - y0;
-    
+
     if dx &gt; dy
         scaled = dx/dy;
         upper_x = scaled;
@@ -95,7 +95,7 @@ end</code></pre>
 
     assert ((<span class="fl">0</span> &lt; upper_x) &amp;&amp; (upper_x &lt;= <span class="fl">1.0</span>), <span class="st">&#39;Calculated upper X coordinate invalid&#39;</span>);
     assert ((<span class="fl">0</span> &lt; upper_y) &amp;&amp; (upper_y &lt;= <span class="fl">1.0</span>), <span class="st">&#39;Calculated upper Y coordinate invalid&#39;</span>);
-    
+
     normalized = [<span class="fl">0</span>, <span class="fl">0</span>, upper_x, upper_y];
 end</code></pre>
 <p>The first three preconditions catch invalid inputs.</p>
@@ -111,8 +111,8 @@ end</code></pre>
 <pre class="output"><code>error: Calculated upper X coordinate invalid</code></pre>
 <p>Re-reading our function, we realize that line 19 should should divide <code>dy</code> by <code>dx</code>. If we had left out the assertion at the end of the function, we would have created and returned something that had the right shape as a valid answer, but wasn’t. Detecting and debugging <em>that</em> would almost certainly have taken more time in the long run than writing the assertion.</p>
 <p>But assertions aren’t just about catching errors: they also help people understand programs. Each assertion gives the person reading the program a chance to check (consciously or otherwise) that their understanding matches what the code is doing.</p>
-<p>Most good programmers follow two rules when adding assertions to their code. The first is, “<a href="rules.html#fail-early-fail-often">fail early, fail often</a>”. The greater the distance between when and where an error occurs and when it’s noticed, the harder the error will be to debug, so good code catches mistakes as early as possible.</p>
-<p>The second rule is, “<a href="rules.html#turn-bugs-into-assertions-or-tests">turn bugs into assertions or tests</a>”. If you made a mistake in a piece of code, the odds are good that you have made other mistakes nearby, or will make the same mistake (or a related one) the next time you change it. Writing assertions to check that you haven’t <a href="gloss.html#regression">regressed</a> (i.e., haven’t re-introduced an old problem) can save a lot of time in the long run, and helps to warn people who are reading the code (including your future self) that this bit is tricky.</p>
+<p>Most good programmers follow two rules when adding assertions to their code. The first is, <em>fail early, fail often</em>. The greater the distance between when and where an error occurs and when it’s noticed, the harder the error will be to debug, so good code catches mistakes as early as possible.</p>
+<p>The second rule is, <em>turn bugs into assertions or tests</em>. If you made a mistake in a piece of code, the odds are good that you have made other mistakes nearby, or will make the same mistake (or a related one) the next time you change it. Writing assertions to check that you haven’t <a href="reference.html#regression">regressed</a> (i.e., haven’t re-introduced an old problem) can save a lot of time in the long run, and helps to warn people who are reading the code (including your future self) that this bit is tricky.</p>
 <div id="finding-conditions" class="challenge panel panel-success">
 <div class="panel-heading">
 <h2><span class="glyphicon glyphicon-pencil"></span>Finding conditions</h2>
@@ -137,7 +137,7 @@ end</code></pre>
 <li>Write a <code>range_overlap</code> function that should pass those tests.</li>
 <li>If <code>range_overlap</code> produces any wrong answers, fix it and re-run the test functions.</li>
 </ol>
-<p>Writing the tests <em>before</em> writing the function they exercise is called <a href="gloss.html#test-driven-development">test-driven development</a> (TDD). Its advocates believe it produces better code faster because:</p>
+<p>Writing the tests <em>before</em> writing the function they exercise is called <a href="reference.html#test-driven-development">test-driven development</a> (TDD). Its advocates believe it produces better code faster because:</p>
 <ol style="list-style-type: decimal">
 <li><p>If people write tests after writing the thing to be tested, they are subject to confirmation bias, i.e., they subconsciously write tests to show that their code is correct, rather than to find errors.</p></li>
 <li><p>Writing tests helps programmers figure out what the function is actually supposed to do.</p></li>
@@ -158,7 +158,7 @@ assert(range_overlap([0, 1.0]) == [0, 1.0]);</code></pre>
 <p>Let’s write <code>range_overlap</code>:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">function output_range = range_overlap(varargin)
 
-    <span class="co">% Return common overlap among a set of [low, high] ranges. </span>
+    <span class="co">% Return common overlap among a set of [low, high] ranges.</span>
 
     lowest = -inf;
     highest = +inf;
@@ -192,32 +192,32 @@ end</code></pre>
 </div>
 </div>
 <p>Once testing has uncovered problems, the next step is to fix them. Many novices do this by making more-or-less random changes to their code until it seems to produce the right answer, but that’s very inefficient (and the result is usually only correct for the one case they’re testing). The more experienced a programmer is, the more systematically they debug, and most follow some variation on the rules explained below.</p>
-<p>The first step in debugging something is to <a href="rules.html#know-what-its-supposed-to-do">know what it’s supposed to do</a>. “My program doesn’t work” isn’t good enough: in order to diagnose and fix problems, we need to be able to tell correct output from incorrect. If we can write a test case for the failing case—i.e., if we can assert that with <em>these</em> inputs, the function should produce <em>that</em> result— then we’re ready to start debugging. If we can’t, then we need to figure out how we’re going to know when we’ve fixed things.</p>
+<p>The first step in debugging something is to <em>know what it’s supposed to do</em>. “My program doesn’t work” isn’t good enough: in order to diagnose and fix problems, we need to be able to tell correct output from incorrect. If we can write a test case for the failing case—i.e., if we can assert that with <em>these</em> inputs, the function should produce <em>that</em> result— then we’re ready to start debugging. If we can’t, then we need to figure out how we’re going to know when we’ve fixed things.</p>
 <p>But writing test cases for scientific software is frequently harder than writing test cases for commercial applications, because if we knew what the output of the scientific code was supposed to be, we wouldn’t be running the software: we’d be writing up our results and moving on to the next program. In practice, scientists tend to do the following:</p>
 <ol style="list-style-type: decimal">
 <li><p><em>Test with simplified data.</em> Before doing statistics on a real data set, we should try calculating statistics for a single record, for two identical records, for two records whose values are one step apart, or for some other case where we can calculate the right answer by hand.</p></li>
 <li><p><em>Test a simplified case.</em> If our program is supposed to simulate magnetic eddies in rapidly-rotating blobs of supercooled helium, our first test should be a blob of helium that isn’t rotating, and isn’t being subjected to any external electromagnetic fields. Similarly, if we’re looking at the effects of climate change on speciation, our first test should hold temperature, precipitation, and other factors constant.</p></li>
-<li><p><em>Compare to an oracle.</em> A <a href="gloss.html#test-oracle">test oracle</a> is something—experimental data, an older program whose results are trusted, or even a human expert—against which we can compare the results of our new program. If we have a test oracle, we should store its output for particular cases so that we can compare it with our new results as often as we like without re-running that program.</p></li>
+<li><p><em>Compare to an oracle.</em> A <a href="reference.html#test-oracle">test oracle</a> is something—experimental data, an older program whose results are trusted, or even a human expert—against which we can compare the results of our new program. If we have a test oracle, we should store its output for particular cases so that we can compare it with our new results as often as we like without re-running that program.</p></li>
 <li><p><em>Check conservation laws.</em> Mass, energy, and other quantitites are conserved in physical systems, so they should be in programs as well. Similarly, if we are analyzing patient data, the number of records should either stay the same or decrease as we move from one analysis to the next (since we might throw away outliers or records with missing values). If “new” patients start appearing out of nowhere as we move through our pipeline, it’s probably a sign that something is wrong.</p></li>
 <li><p><em>Visualize.</em> Data analysts frequently use simple visualizations to check both the science they’re doing and the correctness of their code (just as we did in the <a href="01-intro.html">opening lesson</a> of this tutorial). This should only be used for debugging as a last resort, though, since it’s very hard to compare two visualizations automatically.</p></li>
 </ol>
-<p>We can only debug something when it fails, so the second step is always to find a test case that <a href="rules.html#make-it-fail-every-time">makes it fail every time</a>. The “every time” part is important because few things are more frustrating than debugging an intermittent problem: if we have to call a function a dozen times to get a single failure, the odds are good that we’ll scroll past the failure when it actually occurs.</p>
+<p>We can only debug something when it fails, so the second step is always to find a test case that <em>make it fail every time</em>. The “every time” part is important because few things are more frustrating than debugging an intermittent problem: if we have to call a function a dozen times to get a single failure, the odds are good that we’ll scroll past the failure when it actually occurs.</p>
 <p>As part of this, it’s always important to check that our code is “plugged in”, i.e., that we’re actually exercising the problem that we think we are. Every programmer has spent hours chasing a bug, only to realize that they were actually calling their code on the wrong data set or with the wrong configuration parameters, or are using the wrong version of the software entirely. Mistakes like these are particularly likely to happen when we’re tired, frustrated, and up against a deadline, which is one of the reasons late-night (or overnight) coding sessions are almost never worthwhile.</p>
-<p>If it takes 20 minutes for the bug to surface, we can only do three experiments an hour. That doesn’t must mean we’ll get less data in more time: we’re also more likely to be distracted by other things as we wait for our program to fail, which means the time we <em>are</em> spending on the problem is less focused. It’s therefore critical to <a href="rules.html#make-it-fail-fast">make it fail fast</a>.</p>
+<p>If it takes 20 minutes for the bug to surface, we can only do three experiments an hour. That doesn’t must mean we’ll get less data in more time: we’re also more likely to be distracted by other things as we wait for our program to fail, which means the time we <em>are</em> spending on the problem is less focused. It’s therefore critical to <em>make it fail fast</em>.</p>
 <p>As well as making the program fail fast in time, we want to make it fail fast in space, i.e., we want to localize the failure to the smallest possible region of code:</p>
 <ol style="list-style-type: decimal">
 <li><p>The smaller the gap between cause and effect, the easier the connection is to find. Many programmers therefore use a divide and conquer strategy to find bugs, i.e., if the output of a function is wrong, they check whether things are OK in the middle, then concentrate on either the first or second half, and so on.</p></li>
 <li><p>N things can interact in N<sup>2/2</sup> different ways, so every line of code that <em>isn’t</em> run as part of a test means more than one thing we don’t need to worry about.</p></li>
 </ol>
-<p>Replacing random chunks of code is unlikely to do much good. (After all, if you got it wrong the first time, you’ll probably get it wrong the second and third as well.) Good programmers therefore <a href="rules.html#change-one-thing-at-a-time">change one thing at a time</a>, for a reason. They are either trying to gather more information (“is the bug still there if we change the order of the loops?”) or test a fix (“can we make the bug go away by sorting our data before processing it?”).</p>
-<p>Every time we make a change, however small, we should re-run our tests immediately, because the more things we change at once, the harder it is to know what’s responsible for what (those N<sup>2</sup> interactions again). And we should re-run <em>all</em> of our tests: more than half of fixes made to code introduce (or re-introduce) bugs, so re-running all of our tests tells us whether we have <a href="gloss.html#regression">regressed</a>.</p>
-<p>Good scientists keep track of what they’ve done so that they can reproduce their work, and so that they don’t waste time repeating the same experiments or running ones whose results won’t be interesting. Similarly, debugging works best when we <a href="rules.html#keep-track-of-what-youve-done">keep track of what we’ve done</a> and how well it worked. If we find ourselves asking, “Did left followed by right with an odd number of lines cause the crash? Or was it right followed by left? Or was I using an even number of lines?” then it’s time to step away from the computer, take a deep breath, and start working more systematically.</p>
+<p>Replacing random chunks of code is unlikely to do much good. (After all, if you got it wrong the first time, you’ll probably get it wrong the second and third as well.) Good programmers therefore <em>change one thing at a time</em>, for a reason. They are either trying to gather more information (“is the bug still there if we change the order of the loops?”) or test a fix (“can we make the bug go away by sorting our data before processing it?”).</p>
+<p>Every time we make a change, however small, we should re-run our tests immediately, because the more things we change at once, the harder it is to know what’s responsible for what (those N<sup>2</sup> interactions again). And we should re-run <em>all</em> of our tests: more than half of fixes made to code introduce (or re-introduce) bugs, so re-running all of our tests tells us whether we have <a href="reference.html#regression">regressed</a>.</p>
+<p>Good scientists keep track of what they’ve done so that they can reproduce their work, and so that they don’t waste time repeating the same experiments or running ones whose results won’t be interesting. Similarly, debugging works best when we <em>keep track of what we’ve done</em> and how well it worked. If we find ourselves asking, “Did left followed by right with an odd number of lines cause the crash? Or was it right followed by left? Or was I using an even number of lines?” then it’s time to step away from the computer, take a deep breath, and start working more systematically.</p>
 <p>Records are particularly useful when the time comes to ask for help. People are more likely to listen to us when we can explain clearly what we did, and we’re better able to give them the information they need to be useful.</p>
 <p>Version control is often used to reset software to a known state during debugging, and to explore recent changes to code that might be responsible for bugs. In particular, most version control systems have a <code>blame</code> command that will show who last changed particular lines of code…</p>
-<p>And speaking of help: if we can’t find a bug in 10 minutes, we should <a href="rules.html#be-humble">be humble</a> and ask for help. Just explaining the problem aloud is often useful, since hearing what we’re thinking helps us spot inconsistencies and hidden assumptions.</p>
+<p>And speaking of help: if we can’t find a bug in 10 minutes, we should <em>be humble</em> and ask for help. Just explaining the problem aloud is often useful, since hearing what we’re thinking helps us spot inconsistencies and hidden assumptions.</p>
 <p>Asking for help also helps alleviate confirmation bias. If we have just spent an hour writing a complicated program, we want it to work, so we’re likely to keep telling ourselves why it should, rather than searching for the reason it doesn’t. People who aren’t emotionally invested in the code can be more objective, which is why they’re often able to spot the simple mistakes we have overlooked.</p>
 <p>Part of being humble is learning from our mistakes. Programmers tend to get the same things wrong over and over: either they don’t understand the language and libraries they’re working with, or their model of how things work is wrong. In either case, taking note of why the error occurred and checking for it next time quickly turns into not making the mistake at all.</p>
-<p>And that is what makes us most productive in the long run. As the saying goes, “<a href="rules.html#week-hard-work-hour-thought">A week of hard work can sometimes save you an hour of thought</a>.” If we train ourselves to avoid making some kinds of mistakes, to break our code into modular, testable chunks, and to turn every assumption (or mistake) into an assertion, it will actually take us <em>less</em> time to produce working programs, not more.</p>
+<p>And that is what makes us most productive in the long run. As the saying goes, <em>A week of hard work can sometimes save you an hour of thought</em>. If we train ourselves to avoid making some kinds of mistakes, to break our code into modular, testable chunks, and to turn every assumption (or mistake) into an assertion, it will actually take us <em>less</em> time to produce working programs, not more.</p>
         </div>
       </div>
       </article>

--- a/06-defensive.md
+++ b/06-defensive.md
@@ -6,7 +6,7 @@ minutes: 30
 ---
 
 > ## Learning Objectives {.objectives}
-> 
+>
 > *   Explain what an assertion is.
 > *   Add assertions to programs that correctly check the program's state.
 > *   Correctly add precondition and postcondition assertions to functions.
@@ -30,13 +30,13 @@ To achieve that, we need to:
 * make sure we know what "correct" actually means.
 
 The good news is, doing these things will speed up our
-programming, not slow it down. 
+programming, not slow it down.
 
 The first step toward getting the right answers from our programs
 is to assume that mistakes *will* happen
 and to guard against them.
-This is called [defensive programming](gloss.html#defensive-programming),
-and the most common way to do it is to add [assertions](gloss.html#assertion) to our code
+This is called [defensive programming](reference.html#defensive-programming),
+and the most common way to do it is to add [assertions](reference.html#assertion) to our code
 so that it checks itself as it runs.
 An assertion is simply a statement that something must be true at a certain point in a program.
 When MATLAB sees one,
@@ -64,11 +64,11 @@ error: assert (n >= 0) failed
 ~~~
 
 Programs like the Firefox browser are full of assertions: 10-20%
-of the code they contain are there to check that the other 
+of the code they contain are there to check that the other
 80-90% are working correctly. Broadly speaking, assertions fall into
 three categories:
 
-- A [precondition](gloss.html#precondition) is something that must
+- A [precondition](reference.html#precondition) is something that must
 be true at the start of a function in order for it to work correctly.
 - A postcondition is something that the function guarantees is true when
 it finishes.
@@ -88,7 +88,7 @@ sense:
 function normalized = normalize_rectangle(rect)
     % Normalizes a rectangle so that it is at the origin
     % and 1.0 units long on its longest axis:
-    
+
     x0 = rect(1);
     y0 = rect(2);
     x1 = rect(3);
@@ -100,7 +100,7 @@ function normalized = normalize_rectangle(rect)
 
     dx = x1 - x0;
     dy = y1 - y0;
-    
+
     if dx > dy
         scaled = dx/dy;
         upper_x = scaled;
@@ -113,7 +113,7 @@ function normalized = normalize_rectangle(rect)
 
     assert ((0 < upper_x) && (upper_x <= 1.0), 'Calculated upper X coordinate invalid');
     assert ((0 < upper_y) && (upper_y <= 1.0), 'Calculated upper Y coordinate invalid');
-    
+
     normalized = [0, 0, upper_x, upper_y];
 end
 ~~~
@@ -137,7 +137,7 @@ error: Invalid X coordinates
 ~~~
 
 The post-conditions help us catch bugs by telling us when our
-calculations cannot have been correct. For example, 
+calculations cannot have been correct. For example,
 if we normalize a rectangle that is taller than it is
 wide, everything seems OK:
 
@@ -160,9 +160,9 @@ normalize_rectangle([0.0, 0.0, 5.0, 1.0])
 error: Calculated upper X coordinate invalid
 ~~~
 
-Re-reading our function, we realize that line 19 should 
+Re-reading our function, we realize that line 19 should
 should divide `dy` by `dx`. If we had left out the assertion
-at the end of the function, we would have created and 
+at the end of the function, we would have created and
 returned something that had the right shape as
 a valid answer, but wasn't. Detecting and debugging *that*
 would almost certainly have taken more time in
@@ -175,17 +175,17 @@ a chance to check (consciously or otherwise)
 that their understanding matches what the code is doing.
 
 Most good programmers follow two rules when adding assertions to their code.
-The first is, "[fail early, fail often](rules.html#fail-early-fail-often)".
+The first is, *fail early, fail often*.
 The greater the distance between when and where an error occurs and when it's noticed,
 the harder the error will be to debug,
 so good code catches mistakes as early as possible.
 
-The second rule is, "[turn bugs into assertions or tests](rules.html#turn-bugs-into-assertions-or-tests)".
+The second rule is, *turn bugs into assertions or tests*.
 If you made a mistake in a piece of code,
 the odds are good that you have made other mistakes nearby,
 or will make the same mistake (or a related one)
 the next time you change it.
-Writing assertions to check that you haven't [regressed](gloss.html#regression)
+Writing assertions to check that you haven't [regressed](reference.html#regression)
 (i.e., haven't re-introduced an old problem)
 can save a lot of time in the long run,
 and helps to warn people who are reading the code
@@ -194,7 +194,7 @@ that this bit is tricky.
 
 
 > ## Finding conditions {.challenge}
-> 
+>
 > 1. Suppose you are writing a function called `average` that calculates the average of the numbers in a list.
 > What pre-conditions and post-conditions would you write for it?
 > Compare your answer to your neighbor's:
@@ -227,7 +227,7 @@ there's a better way:
 3. If `range_overlap` produces any wrong answers, fix it and re-run the test functions.
 
 Writing the tests *before* writing the function they exercise
-is called [test-driven development](gloss.html#test-driven-development) (TDD).
+is called [test-driven development](reference.html#test-driven-development) (TDD).
 Its advocates believe it produces better code faster because:
 
 1. If people write tests after writing the thing to be tested,
@@ -275,7 +275,7 @@ Let's write `range_overlap`:
 ~~~{.matlab}
 function output_range = range_overlap(varargin)
 
-    % Return common overlap among a set of [low, high] ranges. 
+    % Return common overlap among a set of [low, high] ranges.
 
     lowest = -inf;
     highest = +inf;
@@ -298,7 +298,7 @@ And now when we run the tests:
 ~~~{.matlab}
 test_range_overlap
 ~~~
- 
+
 we shouldn't see an error.
 
 Something important is missing, though.
@@ -307,7 +307,7 @@ or for the case where the ranges overlap at a point. We'll leave this
 as a final assignment.
 
 > ## Fixing Code through Testing {.challenge}
-> Fix `range_overlap`. Uncomment the two commented lines in 
+> Fix `range_overlap`. Uncomment the two commented lines in
 `test_range_overlap`. You'll see that our objective is to return
 a special value: `NaN` (Not a Number), for the following cases:
 >
@@ -329,7 +329,7 @@ the more systematically they debug,
 and most follow some variation on the rules explained below.
 
 The first step in debugging something is to
-[know what it's supposed to do](rules.html#know-what-its-supposed-to-do).
+*know what it's supposed to do*.
 "My program doesn't work" isn't good enough:
 in order to diagnose and fix problems,
 we need to be able to tell correct output from incorrect.
@@ -365,7 +365,7 @@ scientists tend to do the following:
  our first test should hold temperature, precipitation, and other factors constant.
 
 3. *Compare to an oracle.*
- A [test oracle](gloss.html#test-oracle) is something&mdash;experimental data,
+ A [test oracle](reference.html#test-oracle) is something&mdash;experimental data,
  an older program whose results are trusted,
  or even a human expert&mdash;against which we can compare the results of our new program.
  If we have a test oracle,
@@ -396,7 +396,7 @@ scientists tend to do the following:
 
 We can only debug something when it fails,
 so the second step is always to find a test case that
-[makes it fail every time](rules.html#make-it-fail-every-time).
+*make it fail every time*.
 The "every time" part is important because
 few things are more frustrating than debugging an intermittent problem:
 if we have to call a function a dozen times to get a single failure,
@@ -421,7 +421,7 @@ we can only do three experiments an hour.
 That doesn't must mean we'll get less data in more time:
 we're also more likely to be distracted by other things as we wait for our program to fail,
 which means the time we *are* spending on the problem is less focused.
-It's therefore critical to [make it fail fast](rules.html#make-it-fail-fast).
+It's therefore critical to *make it fail fast*.
 
 As well as making the program fail fast in time,
 we want to make it fail fast in space,
@@ -446,13 +446,13 @@ Replacing random chunks of code is unlikely to do much good.
 if you got it wrong the first time,
 you'll probably get it wrong the second and third as well.)
 Good programmers therefore
-[change one thing at a time](rules.html#change-one-thing-at-a-time),
+*change one thing at a time*,
 for a reason.
 They are either trying to gather more information
 ("is the bug still there if we change the order of the loops?")
 or test a fix
 ("can we make the bug go away by sorting our data before processing it?").
- 
+
 Every time we make a change,
 however small,
 we should re-run our tests immediately,
@@ -461,7 +461,7 @@ the harder it is to know what's responsible for what
 (those N<sup>2</sup> interactions again).
 And we should re-run *all* of our tests:
 more than half of fixes made to code introduce (or re-introduce) bugs,
-so re-running all of our tests tells us whether we have [regressed](gloss.html#regression).
+so re-running all of our tests tells us whether we have [regressed](reference.html#regression).
 
 Good scientists keep track of what they've done
 so that they can reproduce their work,
@@ -469,7 +469,7 @@ and so that they don't waste time repeating the same experiments
 or running ones whose results won't be interesting.
 Similarly,
 debugging works best when we
-[keep track of what we've done](rules.html#keep-track-of-what-youve-done)
+*keep track of what we've done*
 and how well it worked.
 If we find ourselves asking,
 "Did left followed by right with an odd number of lines cause the crash?
@@ -478,7 +478,7 @@ Or was I using an even number of lines?"
 then it's time to step away from the computer,
 take a deep breath,
 and start working more systematically.
- 
+
 Records are particularly useful when the time comes to ask for help.
 People are more likely to listen to us
 when we can explain clearly what we did,
@@ -492,7 +492,7 @@ that will show who last changed particular lines of code...
 
 And speaking of help:
 if we can't find a bug in 10 minutes,
-we should [be humble](rules.html#be-humble) and ask for help.
+we should *be humble* and ask for help.
 Just explaining the problem aloud is often useful,
 since hearing what we're thinking helps us spot inconsistencies and hidden assumptions.
 
@@ -515,7 +515,7 @@ quickly turns into not making the mistake at all.
 
 And that is what makes us most productive in the long run.
 As the saying goes,
-"[A week of hard work can sometimes save you an hour of thought](rules.html#week-hard-work-hour-thought)."
+*A week of hard work can sometimes save you an hour of thought*.
 If we train ourselves to avoid making some kinds of mistakes,
 to break our code into modular, testable chunks,
 and to turn every assumption (or mistake) into an assertion,

--- a/06-defensive.md
+++ b/06-defensive.md
@@ -193,7 +193,7 @@ and helps to warn people who are reading the code
 that this bit is tricky.
 
 
-> ## Finding conditions {.challenges}
+> ## Finding conditions {.challenge}
 > 
 > 1. Suppose you are writing a function called `average` that calculates the average of the numbers in a list.
 > What pre-conditions and post-conditions would you write for it?

--- a/index.md
+++ b/index.md
@@ -1,6 +1,5 @@
 ---
 layout: lesson
-root: ../..
 title: Programming with MATLAB
 ---
 The best way to learn how to program is to do something useful, so this

--- a/reference.html
+++ b/reference.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="generator" content="pandoc">
+    <title>Software Carpentry: </title>
+    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" type="text/css" href="css/bootstrap/bootstrap.css" />
+    <link rel="stylesheet" type="text/css" href="css/bootstrap/bootstrap-theme.css" />
+    <link rel="stylesheet" type="text/css" href="css/swc.css" />
+    <link rel="alternate" type="application/rss+xml" title="Software Carpentry Blog" href="http://software-carpentry.org/feed.xml"/>
+    <meta charset="UTF-8" />
+    <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->
+    <!--[if lt IE 9]>
+      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+  </head>
+  <body class="lesson">
+    <div class="container card">
+      <div class="banner">
+        <a href="http://software-carpentry.org" title="Software Carpentry">
+          <img alt="Software Carpentry banner" src="img/software-carpentry-banner.png" />
+        </a>
+      </div>
+      <article>
+      <div class="row">
+        <div class="col-md-10 col-md-offset-1">
+          <h1 class="title"></h1>
+          
+<h2 id="glossary">Glossary</h2>
+        </div>
+      </div>
+      </article>
+      <div class="footer">
+        <a class="label swc-blue-bg" href="http://software-carpentry.org">Software Carpentry</a>
+        <a class="label swc-blue-bg" href="https://github.com/swcarpentry/matlab-novice-inflammation">Source</a>
+        <a class="label swc-blue-bg" href="mailto:admin@software-carpentry.org">Contact</a>
+        <a class="label swc-blue-bg" href="LICENSE.html">License</a>
+      </div>
+    </div>
+    <!-- Javascript placed at the end of the document so the pages load faster -->
+    <script src="http://software-carpentry.org/v5/js/jquery-1.9.1.min.js"></script>
+    <script src="css/bootstrap/bootstrap-js/bootstrap.js"></script>
+  </body>
+</html>

--- a/reference.html
+++ b/reference.html
@@ -78,9 +78,6 @@
 <dt><span id="documentation">documentation</span></dt>
 <dd><p>Human-language text written to explain what software does, how it works, or how to use it.</p>
 </dd>
-<dt><span id="dotted-notation">dotted notation</span></dt>
-<dd><p>A two-part notation used in many programming languages in which <code>thing.component</code> refers to the <code>component</code> belonging to <code>thing</code>.</p>
-</dd>
 <dt><span id="empty-string">empty string</span></dt>
 <dd><p>A character string containing no characters, often thought of as the “zero” of text.</p>
 </dd>
@@ -95,12 +92,6 @@
 </dd>
 <dt><span id="function-call">function call</span></dt>
 <dd><p>A use of a function in another piece of software.</p>
-</dd>
-<dt><span id="immutable">immutable</span></dt>
-<dd><p>Unchangeable. The value of immutable data cannot be altered after it has been created. See also: <a href="#mutable">mutable</a>.</p>
-</dd>
-<dt><span id="import">import</span></dt>
-<dd><p>To load a <a href="#library">library</a> into a program.</p>
 </dd>
 <dt><span id="in-place-operators">in-place operators</span></dt>
 <dd><p>An operator such as <code>+=</code> that provides a shorthand notation for the common case in which the variable being assigned to is also an operand on the right hand side of the assignment. For example, the statement <code>x += 3</code> means the same thing as <code>x = x + 3</code>.</p>
@@ -123,15 +114,6 @@
 <dt><span id="loop-variable">loop variable</span></dt>
 <dd><p>The variable that keeps track of the progress of the loop.</p>
 </dd>
-<dt><span id="member">member</span></dt>
-<dd><p>A variable contained within an <a href="#object">object</a>.</p>
-</dd>
-<dt><span id="method">method</span></dt>
-<dd><p>A function which is tied to a particular <a href="#object">object</a>. Each of an object’s methods typically implements one of the things it can do, or one of the questions it can answer.</p>
-</dd>
-<dt><span id="object">object</span></dt>
-<dd><p>FIXME</p>
-</dd>
 <dt><span id="outer-loop">outer loop</span></dt>
 <dd><p>A loop that contains another loop. See also: <a href="#inner-loop">inner loop</a>.</p>
 </dd>
@@ -150,14 +132,8 @@
 <dt><span id="regression">regression</span></dt>
 <dd><p>To re-introduce a bug that was once fixed.</p>
 </dd>
-<dt><span id="return-statement">return statement</span></dt>
-<dd><p>A statement that causes a function to stop executing and return a value to its caller immediately.</p>
-</dd>
 <dt><span id="rgb">RGB</span></dt>
 <dd><p>An <a href="#additive-color-model">additive model</a> that represents colors as combinations of red, green, and blue. Each color’s value is typically in the range 0..255 (i.e., a one-byte integer).</p>
-</dd>
-<dt><span id="sequence">sequence</span></dt>
-<dd><p>FIXME</p>
 </dd>
 <dt><span id="shape">shape</span></dt>
 <dd><p>An array’s dimensions, represented as a vector. For example, a 5×3 array’s shape is <code>(5,3)</code>.</p>
@@ -188,9 +164,6 @@
 </dd>
 <dt><span id="test-driven-development">test-driven development</span></dt>
 <dd><p>The practice of writing unit tests <em>before</em> writing the code they test.</p>
-</dd>
-<dt><span id="tuple">tuple</span></dt>
-<dd><p>An <a href="#immutable">immutable</a> <a href="#sequence">sequence</a> of values.</p>
 </dd>
 <dt><span id="type">type</span></dt>
 <dd><p>CHECKME The classification of something in a program (for example, the contents of a variable) as a kind of number (e.g. <a href="#float">floating-point</a>, <a href="#integer">integer</a>), <a href="#string">string</a>, or something else.</p>

--- a/reference.html
+++ b/reference.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="generator" content="pandoc">
-    <title>Software Carpentry: </title>
+    <title>Software Carpentry: Programming with Python</title>
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="css/bootstrap/bootstrap.css" />
@@ -26,9 +26,188 @@
       <article>
       <div class="row">
         <div class="col-md-10 col-md-offset-1">
-          <h1 class="title"></h1>
-          
+          <h1 class="title">Programming with Python</h1>
+          <h2 class="subtitle">Reference</h2>
 <h2 id="glossary">Glossary</h2>
+<dl>
+<dt><span id="additive-color-model">additive color model</span></dt>
+<dd><p>A way to represent colors as the sum of contributions from primary colors such as <a href="#rgb">red, green, and blue</a>.</p>
+</dd>
+<dt><span id="argument">argument</span></dt>
+<dd><p>A value given to a function or program when it runs. The term is often used interchangeably (and inconsistently) with <a href="#parameter">parameter</a>.</p>
+</dd>
+<dt><span id="assertion">assertion</span></dt>
+<dd><p>An expression which is supposed to be true at a particular point in a program. Programmers typically put assertions in their code to check for errors; if the assertion fails (i.e., if the expression evaluates as false), the program halts and produces an error message. See also: <a href="#invariant">invariant</a>, <a href="#precondition">precondition</a>, <a href="#postcondition">postcondition</a>.</p>
+</dd>
+<dt><span id="assign">assign</span></dt>
+<dd><p>To give a value a name by associating a variable with it.</p>
+</dd>
+<dt><span id="body">body</span></dt>
+<dd><p>(of a function): the statements that are executed when a function runs.</p>
+</dd>
+<dt><span id="call-stack">call stack</span></dt>
+<dd><p>A data structure inside a running program that keeps track of active function calls.</p>
+</dd>
+<dt><span id="case-insensitive">case-insensitive</span></dt>
+<dd><p>Treating text as if upper and lower case characters of the same letter were the same. See also: <a href="#case-sensitive">case-sensitive</a>.</p>
+</dd>
+<dt><span id="case-sensitive">case-sensitive</span></dt>
+<dd><p>Treating text as if upper and lower case characters of the same letter are different. See also: <a href="#case-insensitive">case-insensitive</a>.</p>
+</dd>
+<dt><span id="comment">comment</span></dt>
+<dd><p>A remark in a program that is intended to help human readers understand what is going on, but is ignored by the computer. Comments in Python, R, and the Unix shell start with a <code>#</code> character and run to the end of the line; comments in SQL start with <code>--</code>, and other languages have other conventions.</p>
+</dd>
+<dt><span id="compose">compose</span></dt>
+<dd><p>To apply one function to the result of another, such as <code>f(g(x))</code>.</p>
+</dd>
+<dt><span id="conditional-statement">conditional statement</span></dt>
+<dd><p>A statement in a program that might or might not be executed depending on whether a test is true or false.</p>
+</dd>
+<dt><span id="comma-separated-values">comma-separated values</span></dt>
+<dd><p>(CSV) A common textual representation for tables in which the values in each row are separated by commas.</p>
+</dd>
+<dt><span id="default-value">default value</span></dt>
+<dd><p>A value to use for a <a href="#parameter">parameter</a> if nothing is specified explicitly.</p>
+</dd>
+<dt><span id="defensive-programming">defensive programming</span></dt>
+<dd><p>The practice of writing programs that check their own operation to catch errors as early as possible.</p>
+</dd>
+<dt><span id="delimiter">delimiter</span></dt>
+<dd><p>A character or characters used to separate individual values, such as the commas between columns in a <a href="#comma-separated-values">CSV</a> file.</p>
+</dd>
+<dt><span id="docstring">docstring</span></dt>
+<dd><p>Short for “documentation string”, this refers to textual documentation embedded in Python programs. Unlike comments, docstrings are preserved in the running program and can be examined in interactive sessions.</p>
+</dd>
+<dt><span id="documentation">documentation</span></dt>
+<dd><p>Human-language text written to explain what software does, how it works, or how to use it.</p>
+</dd>
+<dt><span id="dotted-notation">dotted notation</span></dt>
+<dd><p>A two-part notation used in many programming languages in which <code>thing.component</code> refers to the <code>component</code> belonging to <code>thing</code>.</p>
+</dd>
+<dt><span id="empty-string">empty string</span></dt>
+<dd><p>A character string containing no characters, often thought of as the “zero” of text.</p>
+</dd>
+<dt><span id="encapsulation">encapsulation</span></dt>
+<dd><p>The practice of hiding something’s implementation details so that the rest of a program can worry about <em>what</em> it does rather than <em>how</em> it does it.</p>
+</dd>
+<dt><span id="floating-point-number">floating-point number</span></dt>
+<dd><p>A number containing a fractional part and an exponent. See also: <a href="#integer">integer</a>.</p>
+</dd>
+<dt><span id="for-loop">for loop</span></dt>
+<dd><p>A loop that is executed once for each value in some kind of set, list, or range. See also: <a href="#while-loop">while loop</a>.</p>
+</dd>
+<dt><span id="function-call">function call</span></dt>
+<dd><p>A use of a function in another piece of software.</p>
+</dd>
+<dt><span id="immutable">immutable</span></dt>
+<dd><p>Unchangeable. The value of immutable data cannot be altered after it has been created. See also: <a href="#mutable">mutable</a>.</p>
+</dd>
+<dt><span id="import">import</span></dt>
+<dd><p>To load a <a href="#library">library</a> into a program.</p>
+</dd>
+<dt><span id="in-place-operators">in-place operators</span></dt>
+<dd><p>An operator such as <code>+=</code> that provides a shorthand notation for the common case in which the variable being assigned to is also an operand on the right hand side of the assignment. For example, the statement <code>x += 3</code> means the same thing as <code>x = x + 3</code>.</p>
+</dd>
+<dt><span id="index">index</span></dt>
+<dd><p>A subscript that specifies the location of a single value in a collection, such as a single pixel in an image.</p>
+</dd>
+<dt><span id="inner-loop">inner loop</span></dt>
+<dd><p>A loop that is inside another loop. See also: <a href="#outer-loop">outer loop</a>.</p>
+</dd>
+<dt><span id="integer">integer</span></dt>
+<dd><p>A whole number, such as -12343. See also: <a href="#floating-point-number">floating-point number</a>.</p>
+</dd>
+<dt><span id="invariant">invariant</span></dt>
+<dd><p>An expression whose value doesn’t change during the execution of a program, typically used in an <a href="#assertion">assertion</a>. See also: <a href="#precondition">precondition</a>, <a href="#postcondition">postcondition</a>.</p>
+</dd>
+<dt><span id="library">library</span></dt>
+<dd><p>A family of code units (functions, classes, variables) that implement a set of related tasks.</p>
+</dd>
+<dt><span id="loop-variable">loop variable</span></dt>
+<dd><p>The variable that keeps track of the progress of the loop.</p>
+</dd>
+<dt><span id="member">member</span></dt>
+<dd><p>A variable contained within an <a href="#object">object</a>.</p>
+</dd>
+<dt><span id="method">method</span></dt>
+<dd><p>A function which is tied to a particular <a href="#object">object</a>. Each of an object’s methods typically implements one of the things it can do, or one of the questions it can answer.</p>
+</dd>
+<dt><span id="object">object</span></dt>
+<dd><p>FIXME</p>
+</dd>
+<dt><span id="outer-loop">outer loop</span></dt>
+<dd><p>A loop that contains another loop. See also: <a href="#inner-loop">inner loop</a>.</p>
+</dd>
+<dt><span id="parameter">parameter</span></dt>
+<dd><p>A variable named in the function’s declaration that is used to hold a value passed into the call. The term is often used interchangeably (and inconsistently) with <a href="#argument">argument</a>.</p>
+</dd>
+<dt><span id="pipe">pipe</span></dt>
+<dd><p>A connection from the output of one program to the input of another. When two or more programs are connected in this way, they are called a “pipeline”.</p>
+</dd>
+<dt><span id="postcondition">postcondition</span></dt>
+<dd><p>A condition that a function (or other block of code) guarantees is true once it has finished running. Postconditions are often represented using <a href="#assertion">assertions</a>.</p>
+</dd>
+<dt><span id="precondition">precondition</span></dt>
+<dd><p>A condition that must be true in order for a function (or other block of code) to run correctly.</p>
+</dd>
+<dt><span id="regression">regression</span></dt>
+<dd><p>To re-introduce a bug that was once fixed.</p>
+</dd>
+<dt><span id="return-statement">return statement</span></dt>
+<dd><p>A statement that causes a function to stop executing and return a value to its caller immediately.</p>
+</dd>
+<dt><span id="rgb">RGB</span></dt>
+<dd><p>An <a href="#additive-color-model">additive model</a> that represents colors as combinations of red, green, and blue. Each color’s value is typically in the range 0..255 (i.e., a one-byte integer).</p>
+</dd>
+<dt><span id="sequence">sequence</span></dt>
+<dd><p>FIXME</p>
+</dd>
+<dt><span id="shape">shape</span></dt>
+<dd><p>An array’s dimensions, represented as a vector. For example, a 5×3 array’s shape is <code>(5,3)</code>.</p>
+</dd>
+<dt><span id="silent-failure">silent failure</span></dt>
+<dd><p>Failing without producing any warning messages. Silent failures are hard to detect and debug.</p>
+</dd>
+<dt><span id="slice">slice</span></dt>
+<dd><p>A regular subsequence of a larger sequence, such as the first five elements or every second element.</p>
+</dd>
+<dt><span id="stack-frame">stack frame</span></dt>
+<dd><p>A data structure that provides storage for a function’s local variables. Each time a function is called, a new stack frame is created and put on the top of the <a href="#call-stack">call stack</a>. When the function returns, the stack frame is discarded.</p>
+</dd>
+<dt><span id="standard-input">standard input</span></dt>
+<dd><p>A process’s default input stream. In interactive command-line applications, it is typically connected to the keyboard; in a <a href="#pipe">pipe</a>, it receives data from the <a href="#standard-output">standard output</a> of the preceding process.</p>
+</dd>
+<dt><span id="standard-output">standard output</span></dt>
+<dd><p>A process’s default output stream. In interactive command-line applications, data sent to standard output is displayed on the screen; in a <a href="#pipe">pipe</a>, it is passed to the <a href="#standard-input">standard input</a> of the next process.</p>
+</dd>
+<dt><span id="string">string</span></dt>
+<dd><p>Short for “character string”, a <a href="#sequence">sequence</a> of zero or more characters.</p>
+</dd>
+<dt><span id="syntax-error">syntax error</span></dt>
+<dd><p>CHECKME: a programming error that occurs when statements are in an order or contain characters not expected by the programming language</p>
+</dd>
+<dt><span id="test-oracle">test oracle</span></dt>
+<dd><p>A program, device, data set, or human being against which the results of a test can be compared.</p>
+</dd>
+<dt><span id="test-driven-development">test-driven development</span></dt>
+<dd><p>The practice of writing unit tests <em>before</em> writing the code they test.</p>
+</dd>
+<dt><span id="traceback">traceback</span></dt>
+<dd><p>CHECKME In Python, a list of the sequence of function calls that led to an error.</p>
+</dd>
+<dt><span id="tuple">tuple</span></dt>
+<dd><p>An <a href="#immutable">immutable</a> <a href="#sequence">sequence</a> of values.</p>
+</dd>
+<dt><span id="type">type</span></dt>
+<dd><p>CHECKME The classification of something in a program (for example, the contents of a variable) as a kind of number (e.g. <a href="#float">floating-point</a>, <a href="#integer">integer</a>), <a href="#string">string</a>, or something else.</p>
+</dd>
+<dt><span id="type-of-error">type of error</span></dt>
+<dd><p>CHECKME Indicates the nature of an error in a program, for example, <code>IOError</code> in Python refers to problems in input/output. See also <a href="#syntax-error">syntax error</a>.</p>
+</dd>
+<dt><span id="while-loop">while loop</span></dt>
+<dd><p>A loop that keeps executing as long as some condition is true. See also: <a href="#for-loop">for loop</a>.</p>
+</dd>
+</dl>
         </div>
       </div>
       </article>

--- a/reference.html
+++ b/reference.html
@@ -55,7 +55,7 @@
 <dd><p>Treating text as if upper and lower case characters of the same letter are different. See also: <a href="#case-insensitive">case-insensitive</a>.</p>
 </dd>
 <dt><span id="comment">comment</span></dt>
-<dd><p>A remark in a program that is intended to help human readers understand what is going on, but is ignored by the computer. Comments in MATLAB start with a <code>%</code> character and run to the end of the line; comments in SQL start with <code>--</code>, and other languages have other conventions.</p>
+<dd><p>A remark in a program that is intended to help human readers understand what is going on, but is ignored by the computer. Comments in MATLAB start with a <code>%</code> character and run to the end of the line;</p>
 </dd>
 <dt><span id="compose">compose</span></dt>
 <dd><p>To apply one function to the result of another, such as <code>f(g(x))</code>.</p>

--- a/reference.html
+++ b/reference.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="generator" content="pandoc">
-    <title>Software Carpentry: Programming with Python</title>
+    <title>Software Carpentry: Programming with MATLAB</title>
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" type="text/css" href="css/bootstrap/bootstrap.css" />
@@ -26,7 +26,7 @@
       <article>
       <div class="row">
         <div class="col-md-10 col-md-offset-1">
-          <h1 class="title">Programming with Python</h1>
+          <h1 class="title">Programming with MATLAB</h1>
           <h2 class="subtitle">Reference</h2>
 <h2 id="glossary">Glossary</h2>
 <dl>
@@ -55,7 +55,7 @@
 <dd><p>Treating text as if upper and lower case characters of the same letter are different. See also: <a href="#case-insensitive">case-insensitive</a>.</p>
 </dd>
 <dt><span id="comment">comment</span></dt>
-<dd><p>A remark in a program that is intended to help human readers understand what is going on, but is ignored by the computer. Comments in Python, R, and the Unix shell start with a <code>#</code> character and run to the end of the line; comments in SQL start with <code>--</code>, and other languages have other conventions.</p>
+<dd><p>A remark in a program that is intended to help human readers understand what is going on, but is ignored by the computer. Comments in MATLAB start with a <code>%</code> character and run to the end of the line; comments in SQL start with <code>--</code>, and other languages have other conventions.</p>
 </dd>
 <dt><span id="compose">compose</span></dt>
 <dd><p>To apply one function to the result of another, such as <code>f(g(x))</code>.</p>
@@ -74,9 +74,6 @@
 </dd>
 <dt><span id="delimiter">delimiter</span></dt>
 <dd><p>A character or characters used to separate individual values, such as the commas between columns in a <a href="#comma-separated-values">CSV</a> file.</p>
-</dd>
-<dt><span id="docstring">docstring</span></dt>
-<dd><p>Short for “documentation string”, this refers to textual documentation embedded in Python programs. Unlike comments, docstrings are preserved in the running program and can be examined in interactive sessions.</p>
 </dd>
 <dt><span id="documentation">documentation</span></dt>
 <dd><p>Human-language text written to explain what software does, how it works, or how to use it.</p>
@@ -192,17 +189,11 @@
 <dt><span id="test-driven-development">test-driven development</span></dt>
 <dd><p>The practice of writing unit tests <em>before</em> writing the code they test.</p>
 </dd>
-<dt><span id="traceback">traceback</span></dt>
-<dd><p>CHECKME In Python, a list of the sequence of function calls that led to an error.</p>
-</dd>
 <dt><span id="tuple">tuple</span></dt>
 <dd><p>An <a href="#immutable">immutable</a> <a href="#sequence">sequence</a> of values.</p>
 </dd>
 <dt><span id="type">type</span></dt>
 <dd><p>CHECKME The classification of something in a program (for example, the contents of a variable) as a kind of number (e.g. <a href="#float">floating-point</a>, <a href="#integer">integer</a>), <a href="#string">string</a>, or something else.</p>
-</dd>
-<dt><span id="type-of-error">type of error</span></dt>
-<dd><p>CHECKME Indicates the nature of an error in a program, for example, <code>IOError</code> in Python refers to problems in input/output. See also <a href="#syntax-error">syntax error</a>.</p>
 </dd>
 <dt><span id="while-loop">while loop</span></dt>
 <dd><p>A loop that keeps executing as long as some condition is true. See also: <a href="#for-loop">for loop</a>.</p>

--- a/reference.md
+++ b/reference.md
@@ -1,0 +1,3 @@
+## Glossary
+
+

--- a/reference.md
+++ b/reference.md
@@ -1,3 +1,247 @@
+---
+layout: page
+title: Programming with Python
+subtitle: Reference
+---
+
 ## Glossary
 
+additive color model
+:   A way to represent colors as the sum of contributions from primary colors
+	such as [red, green, and blue](#rgb).
 
+argument
+:   A value given to a function or program when it runs.
+    The term is often used interchangeably (and inconsistently) with [parameter](#parameter).
+
+assertion
+:   An expression which is supposed to be true at a particular point in a program.
+    Programmers typically put assertions in their code to check for errors;
+    if the assertion fails (i.e., if the expression evaluates as false),
+    the program halts and produces an error message.
+    See also: [invariant](#invariant), [precondition](#precondition), [postcondition](#postcondition).
+
+assign
+:   To give a value a name by associating a variable with it.
+
+body
+:   (of a function): the statements that are executed when a function runs.
+
+call stack
+:   A data structure inside a running program that keeps track of active function calls.
+
+case-insensitive
+:   Treating text as if upper and lower case characters of the same letter were the same.
+    See also: [case-sensitive](#case-sensitive).
+
+case-sensitive
+:   Treating text as if upper and lower case characters of the same letter are different.
+    See also: [case-insensitive](#case-insensitive).
+
+comment
+:   A remark in a program that is intended to help human readers understand what is going on,
+    but is ignored by the computer.
+    Comments in Python, R, and the Unix shell start with a `#` character and run to the end of the line;
+    comments in SQL start with `--`,
+    and other languages have other conventions.
+
+compose
+:   To apply one function to the result of another, such as `f(g(x))`.
+
+conditional statement
+:   A statement in a program that might or might not be executed
+    depending on whether a test is true or false.
+
+comma-separated values
+:   (CSV) A common textual representation for tables
+    in which the values in each row are separated by commas.
+
+default value
+:   A value to use for a [parameter](#parameter) if nothing is specified explicitly.
+
+defensive programming
+:   The practice of writing programs that check their own operation to catch errors as early as possible.
+
+delimiter
+:   A character or characters used to separate individual values,
+    such as the commas between columns in a [CSV](#comma-separated-values) file.
+
+docstring
+:   Short for "documentation string",
+    this refers to textual documentation embedded in Python programs.
+    Unlike comments, docstrings are preserved in the running program
+    and can be examined in interactive sessions.
+
+documentation
+:   Human-language text written to explain what software does,
+    how it works, or how to use it.
+
+dotted notation
+:   A two-part notation used in many programming languages
+    in which `thing.component` refers to the `component` belonging to `thing`.
+
+empty string
+:   A character string containing no characters,
+    often thought of as the "zero" of text.
+
+encapsulation
+:   The practice of hiding something's implementation details
+    so that the rest of a program can worry about *what* it does
+    rather than *how* it does it.
+
+floating-point number
+:   A number containing a fractional part and an exponent.
+    See also: [integer](#integer).
+
+for loop
+:   A loop that is executed once for each value in some kind of set, list, or range.
+    See also: [while loop](#while-loop).
+
+function call
+:   A use of a function in another piece of software.
+
+immutable
+:   Unchangeable.
+    The value of immutable data cannot be altered after it has been created.
+    See also: [mutable](#mutable).
+
+import
+:   To load a [library](#library) into a program.
+
+in-place operators
+:   An operator such as `+=` that provides a shorthand notation for
+    the common case in which the variable being assigned to
+    is also an operand on the right hand side of the assignment.
+    For example, the statement `x += 3` means the same thing as `x = x + 3`.
+
+index
+:   A subscript that specifies the location of a single value in a collection,
+    such as a single pixel in an image.
+
+inner loop
+:   A loop that is inside another loop. See also: [outer loop](#outer-loop).
+
+integer
+:   A whole number, such as -12343. See also: [floating-point number](#floating-point-number).
+
+invariant
+:   An expression whose value doesn't change during the execution of a program,
+    typically used in an [assertion](#assertion).
+    See also: [precondition](#precondition), [postcondition](#postcondition).
+
+library
+:   A family of code units (functions, classes, variables) that implement a set of
+    related tasks.
+
+loop variable
+:   The variable that keeps track of the progress of the loop.
+
+member
+:   A variable contained within an [object](#object).
+
+method
+:   A function which is tied to a particular [object](#object).
+    Each of an object's methods typically implements one of the things it can do,
+    or one of the questions it can answer.
+
+object
+:   FIXME
+
+outer loop
+:   A loop that contains another loop.
+    See also: [inner loop](#inner-loop).
+
+parameter
+:   A variable named in the function's declaration that is used to hold a value passed into the call.
+    The term is often used interchangeably (and inconsistently) with [argument](#argument).
+
+pipe
+:   A connection from the output of one program to the input of another.
+    When two or more programs are connected in this way, they are called a "pipeline".
+
+postcondition
+:   A condition that a function (or other block of code) guarantees is true
+    once it has finished running.
+    Postconditions are often represented using [assertions](#assertion).
+
+precondition
+:   A condition that must be true in order for a function (or other block of code) to run correctly.
+
+regression
+:   To re-introduce a bug that was once fixed.
+
+return statement
+:   A statement that causes a function to stop executing and return a value to its caller immediately.
+
+RGB
+:   An [additive model](#additive-color-model)
+    that represents colors as combinations of red, green, and blue.
+    Each color's value is typically in the range 0..255
+    (i.e., a one-byte integer).
+
+sequence
+:   FIXME
+
+shape
+:   An array's dimensions, represented as a vector.
+    For example, a 5&times;3 array's shape is `(5,3)`.
+
+silent failure
+:   Failing without producing any warning messages.
+    Silent failures are hard to detect and debug.
+
+slice
+:   A regular subsequence of a larger sequence,
+    such as the first five elements or every second element.
+
+stack frame
+:   A data structure that provides storage for a function's local variables.
+    Each time a function is called, a new stack frame is created
+    and put on the top of the [call stack](#call-stack). When the function returns,
+    the stack frame is discarded.
+
+standard input
+:   A process's default input stream.
+    In interactive command-line applications,
+    it is typically connected to the keyboard; in a [pipe](#pipe),
+    it receives data from the [standard output](#standard-output) of the preceding process.
+
+standard output
+:   A process's default output stream.
+    In interactive command-line applications,
+    data sent to standard output is displayed on the screen;
+    in a [pipe](#pipe),
+    it is passed to the [standard input](#standard-input) of the next process.
+
+string
+:   Short for "character string",
+    a [sequence](#sequence) of zero or more characters.
+
+syntax error
+:   CHECKME: a programming error that occurs when statements are in an order or contain characters
+    not expected by the programming language
+
+test oracle
+:   A program, device, data set, or human being
+    against which the results of a test can be compared.
+
+test-driven development
+:   The practice of writing unit tests *before* writing the code they test.
+
+traceback
+:   CHECKME In Python, a list of the sequence of function calls that led to an error.
+
+tuple
+:   An [immutable](#immutable) [sequence](#sequence) of values.
+
+type
+:   CHECKME The classification of something in a program (for example, the contents of a variable)
+    as a kind of number (e.g. [floating-point](#float), [integer](#integer)), [string](#string), or something else.
+
+type of error
+:   CHECKME Indicates the nature of an error in a program, for example, `IOError` in Python refers to problems in input/output.
+    See also [syntax error](#syntax-error).
+
+while loop
+:   A loop that keeps executing as long as some condition is true.
+    See also: [for loop](#for-loop).

--- a/reference.md
+++ b/reference.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Programming with Python
+title: Programming with MATLAB
 subtitle: Reference
 ---
 
@@ -41,7 +41,7 @@ case-sensitive
 comment
 :   A remark in a program that is intended to help human readers understand what is going on,
     but is ignored by the computer.
-    Comments in Python, R, and the Unix shell start with a `#` character and run to the end of the line;
+    Comments in MATLAB start with a `%` character and run to the end of the line;
     comments in SQL start with `--`,
     and other languages have other conventions.
 
@@ -65,12 +65,6 @@ defensive programming
 delimiter
 :   A character or characters used to separate individual values,
     such as the commas between columns in a [CSV](#comma-separated-values) file.
-
-docstring
-:   Short for "documentation string",
-    this refers to textual documentation embedded in Python programs.
-    Unlike comments, docstrings are preserved in the running program
-    and can be examined in interactive sessions.
 
 documentation
 :   Human-language text written to explain what software does,
@@ -228,19 +222,12 @@ test oracle
 test-driven development
 :   The practice of writing unit tests *before* writing the code they test.
 
-traceback
-:   CHECKME In Python, a list of the sequence of function calls that led to an error.
-
 tuple
 :   An [immutable](#immutable) [sequence](#sequence) of values.
 
 type
 :   CHECKME The classification of something in a program (for example, the contents of a variable)
     as a kind of number (e.g. [floating-point](#float), [integer](#integer)), [string](#string), or something else.
-
-type of error
-:   CHECKME Indicates the nature of an error in a program, for example, `IOError` in Python refers to problems in input/output.
-    See also [syntax error](#syntax-error).
 
 while loop
 :   A loop that keeps executing as long as some condition is true.

--- a/reference.md
+++ b/reference.md
@@ -70,10 +70,6 @@ documentation
 :   Human-language text written to explain what software does,
     how it works, or how to use it.
 
-dotted notation
-:   A two-part notation used in many programming languages
-    in which `thing.component` refers to the `component` belonging to `thing`.
-
 empty string
 :   A character string containing no characters,
     often thought of as the "zero" of text.
@@ -93,14 +89,6 @@ for loop
 
 function call
 :   A use of a function in another piece of software.
-
-immutable
-:   Unchangeable.
-    The value of immutable data cannot be altered after it has been created.
-    See also: [mutable](#mutable).
-
-import
-:   To load a [library](#library) into a program.
 
 in-place operators
 :   An operator such as `+=` that provides a shorthand notation for
@@ -130,17 +118,6 @@ library
 loop variable
 :   The variable that keeps track of the progress of the loop.
 
-member
-:   A variable contained within an [object](#object).
-
-method
-:   A function which is tied to a particular [object](#object).
-    Each of an object's methods typically implements one of the things it can do,
-    or one of the questions it can answer.
-
-object
-:   FIXME
-
 outer loop
 :   A loop that contains another loop.
     See also: [inner loop](#inner-loop).
@@ -164,17 +141,11 @@ precondition
 regression
 :   To re-introduce a bug that was once fixed.
 
-return statement
-:   A statement that causes a function to stop executing and return a value to its caller immediately.
-
 RGB
 :   An [additive model](#additive-color-model)
     that represents colors as combinations of red, green, and blue.
     Each color's value is typically in the range 0..255
     (i.e., a one-byte integer).
-
-sequence
-:   FIXME
 
 shape
 :   An array's dimensions, represented as a vector.
@@ -221,9 +192,6 @@ test oracle
 
 test-driven development
 :   The practice of writing unit tests *before* writing the code they test.
-
-tuple
-:   An [immutable](#immutable) [sequence](#sequence) of values.
 
 type
 :   CHECKME The classification of something in a program (for example, the contents of a variable)

--- a/reference.md
+++ b/reference.md
@@ -42,8 +42,6 @@ comment
 :   A remark in a program that is intended to help human readers understand what is going on,
     but is ignored by the computer.
     Comments in MATLAB start with a `%` character and run to the end of the line;
-    comments in SQL start with `--`,
-    and other languages have other conventions.
 
 compose
 :   To apply one function to the result of another, such as `f(g(x))`.


### PR DESCRIPTION
Added a `reference.md` (just using the one from the Python lessons for now), and fixed all the reference.html related errors.