### PR TITLE
Added callout box linking to Octave

### DIFF
--- a/index.md
+++ b/index.md
@@ -20,8 +20,8 @@ language *well*.
 >
 > [GNU Octave](http://www.gnu.org/software/octave/) is a free and open-source alternative
 > to MATLAB which shares its syntax ([see more about compatibility](http://en.wikipedia.org/wiki/GNU_Octave#MATLAB_compatibility)).
-> Thus, you won't need any commercial license to learn the language albeit we will
-> be using the name of MATLAB.
+> Thus, if you don't have access to MATLAB, you can easily set up Octave
+> on your computer and still work through the lesson.
 
 ## Topics
 

--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ language *well*.
 
 > ## GNU Octave {.challenge}
 >
-> [GNU Octave](http://www.gnu.org/software/octave/) is a free and open-source [alternative
+> [GNU Octave](http://www.gnu.org/software/octave/) is a free and open-source alternative
 > to MATLAB which shares its syntax ([see more about compatibility](http://en.wikipedia.org/wiki/GNU_Octave#MATLAB_compatibility)).
 > The outputs and figures of these lessons were in fact obtained with GNU Octave.
 > Thus, you won't need any commercial license to learn the language albeit we will

--- a/index.md
+++ b/index.md
@@ -16,6 +16,14 @@ But the two most important things are to use whatever language your colleagues
 are using, so that you can share you work with them easily, and to use that
 language *well*.
 
+> ## GNU Octave {.challenge}
+>
+> [GNU Octave](http://www.gnu.org/software/octave/) is a free and open-source [alternative
+> to MATLAB which shares its syntax ([see more about compatibility](http://en.wikipedia.org/wiki/GNU_Octave#MATLAB_compatibility)).
+> The outputs and figures of these lessons were in fact obtained with GNU Octave.
+> Thus, you won't need any commercial license to learn the language albeit we will
+> be using the name of MATLAB.
+
 ## Topics
 
 1.  [Analyzing Patient Data](01-intro.html)

--- a/index.md
+++ b/index.md
@@ -16,11 +16,10 @@ But the two most important things are to use whatever language your colleagues
 are using, so that you can share you work with them easily, and to use that
 language *well*.
 
-> ## GNU Octave {.challenge}
+> ## GNU Octave {.callout}
 >
 > [GNU Octave](http://www.gnu.org/software/octave/) is a free and open-source alternative
 > to MATLAB which shares its syntax ([see more about compatibility](http://en.wikipedia.org/wiki/GNU_Octave#MATLAB_compatibility)).
-> The outputs and figures of these lessons were in fact obtained with GNU Octave.
 > Thus, you won't need any commercial license to learn the language albeit we will
 > be using the name of MATLAB.
 


### PR DESCRIPTION
This is just a draft but I think it would be nice to reference GNU Octave in the lessons. It seems that the outputs are indeed obtained from Octave instead of MATLAB. See Issue  for more information #37 

If there is a better format that {.challenge} for this callout, please let me know :eyes: