### PR TITLE
Update test_range_overlap.m

### DIFF
--- a/code/test_range_overlap.m
+++ b/code/test_range_overlap.m
@@ -1,8 +1,8 @@
 %script test_range_overlap.m
 
 
-% assert(range_overlap([0.0, 1.0], [5.0, 6.0]) == NaN);
-% assert(range_overlap([0.0, 1.0], [1.0, 2.0]) == NaN);
+%assert(range_overlap([0.0, 1.0], [5.0, 6.0]) == NaN);
+%assert(range_overlap([0.0, 1.0], [1.0, 2.0]) == NaN);
 assert(range_overlap([0, 1.0]) == [0, 1.0]);
 assert(range_overlap([2.0, 3.0], [2.0, 4.0]) == [2.0, 3.0]);
 assert(range_overlap([0.0, 1.0], [0.0, 2.0], [-1.0, 1.0]) == [0.0, 1.0]);


### PR DESCRIPTION
Two lines missing from script test_range_overlap. I think the space between the '%' and the commented code was hiding them, rather than allowing these two lines to show as comments as was the intention.