### PR TITLE
Moved assertions earlier in normalise rectangle example

### DIFF
--- a/01-intro.html
+++ b/01-intro.html
@@ -74,7 +74,7 @@
 </ul>
 <p>Reading data from files and writing data to them are essential tasks in scientific computing, and admittedly, something that we’d rather not spend a lot of time thinking about. Fortunately, MATLAB comes with a number of high-level tools to do these things efficiently, sparing us the grisly detail.</p>
 <p>If we know what our data looks like (in this case, we have comma-separated values) and we’re unsure about what command we want to use, we can search the documentation. Type <code>read csv</code> into the documentation toolbar. MATLAB suggests using <code>csvread</code>. If we have a closer look at the documentation, MATLAB also tells us, which in- and output arguments this function has.</p>
-<p>To load the data from our CSV file into MATLAB, type following command into the MATLAB shell, and press <code>Enter</code>:</p>
+<p>To load the data from our CSV file into MATLAB, type the following command into the MATLAB shell, and press <code>Enter</code>:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">csvread(<span class="st">&#39;inflammation-01.csv&#39;</span>)</code></pre>
 <aside class="callout panel panel-info">
 <div class="panel-heading">
@@ -122,20 +122,15 @@ Weight in pounds: 126.5</code></pre>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">patient_data = csvread(<span class="st">&#39;inflammation-01.csv&#39;</span>);</code></pre>
 <p>MATLAB provides a command to list all variables that have been assigned data.</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">who</code></pre>
-<pre class="output"><code>Variables in the current scope:
+<pre class="output"><code>Your variables are:
 
-patient_data
-weight_kg
-weight_lb
-</code></pre>
+patient_data  weight_kg  weight_lb</code></pre>
 <p>To remove a variable from MATLAB, use the <code>clear</code> command:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">clear weight_lb
 who</code></pre>
-<pre class="output"><code>Variables in the current scope:
+<pre class="output"><code>Your variables are:
 
-patient_data
-weight_kg
-</code></pre>
+patient_data  weight_kg</code></pre>
 <p>Alternatively, we can look at the <strong>Workspace</strong>. The workspace contains all variable names and assigned values that we currently work with. As long as they pop up in the workspace, they are universally available. It’s generally a good idea to keep the workspace as clean as possible. To do that, simply type <code>clear all</code>.</p>
 <section class="challenge panel panel-success">
 <div class="panel-heading">

--- a/02-scripts.html
+++ b/02-scripts.html
@@ -63,7 +63,7 @@ plot(ave_inflammation);
 ylabel(<span class="st">&#39;average&#39;</span>)</code></pre>
 <p>MATLAB let’s us save those as images on disk:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab"><span class="co">% save plot to disk as png image:</span>
-print (<span class="st">&#39;-dpng&#39;</span>, <span class="st">&#39;average.png&#39;</span>)</code></pre>
+print (<span class="st">&#39;average&#39;</span>,<span class="st">&#39;-dpng&#39;</span>)</code></pre>
 <p>You might have noticed that we described what we want our code to do using the <code>%</code>-sign. This is another plus of writing scripts: you can comment your code to make it easier to understand when you come back to it after a while.</p>
 <p>Let’s extend our <code>analyze</code> script with commands to create and save plots:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab"><span class="co">% script analyze.m</span>
@@ -89,7 +89,7 @@ plot(min(patient_data, [], <span class="fl">1</span>));
 ylabel(<span class="st">&#39;min&#39;</span>)
 
 <span class="co">% save plot to disk as png image:</span>
-print (<span class="st">&#39;-dpng&#39;</span>, <span class="st">&#39;patient_data-01.png&#39;</span>)</code></pre>
+print (<span class="st">&#39;patient_data-01&#39;</span>,<span class="st">&#39;-dpng&#39;</span>)</code></pre>
 <p>When saving plots to disk, it’s a good idea to turn off their visibility as MATLAB plots them. Let’s add a couple of lines of code to do this:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab"><span class="co">% script analyze.m</span>
 
@@ -116,7 +116,7 @@ plot(min(patient_data, [], <span class="fl">1</span>));
 ylabel(<span class="st">&#39;min&#39;</span>)
 
 <span class="co">% save plot to disk as png image:</span>
-print (<span class="st">&#39;-dpng&#39;</span>, <span class="st">&#39;patient_data-01.png&#39;</span>)
+print (<span class="st">&#39;patient_data-01&#39;</span>,<span class="st">&#39;-dpng&#39;</span>)
 
 close()</code></pre>
 <p>If we call the <code>figure</code> function without any options, MATLAB will open up an empty figure window. Try this on the command line:</p>

--- a/05-func.html
+++ b/05-func.html
@@ -162,7 +162,7 @@ DATA centered around the value.</code></pre>
 <div class="panel-body">
 <ol style="list-style-type: decimal">
 <li><p>Write a function called <code>rescale</code> that takes an array as input and returns an array of the same shape with its values scaled to lie in the range 0.0 to 1.0. (If L and H are the lowest and highest values in the input array, respectively, then the function should map a value v to (v - L)/(H - L).) Be sure to give the function a comment block explaining its use.</p></li>
-<li><p>Run <code>help linspace</code> to see how to use this function to generate regularly-spaced values. Use arrays like this to test your <code>rescale</code> function.</p></li>
+<li><p>Run <code>help linspace</code> to see how to use <code>linspace</code> to generate regularly-spaced values. Use arrays like this to test your <code>rescale</code> function.</p></li>
 <li><p>Write a function <code>run_analysis</code> that accepts a filename as parameter, and displays the three graphs produced in the previous lesson, i.e., <code>run_analysis('inflammation-01.csv')</code> should produce the corresponding graphs for the first data set. Be sure to give your function help text.</p></li>
 </ol>
 </div>

--- a/06-defensive.html
+++ b/06-defensive.html
@@ -66,10 +66,11 @@ end</code></pre>
 <li>A postcondition is something that the function guarantees is true when it finishes.</li>
 <li>An invariant is something that is always true at a particular point inside a piece of code.</li>
 </ul>
-<p>For example, suppose we are representing rectangles using an array of four coordinates <code>(x0, y0, x1, y1)</code>. In order to do some calculations, we need to normalize the rectangle so that it is at the origin and 1.0 units on its longest axis. Here is a function that does that, but checks that its input is correctly formatted and that its result makes sense:</p>
+<p>For example, suppose we are representing rectangles using an array of four coordinates <code>(x0, y0, x1, y1)</code>, such that (x0,y0) are the bottom left coordinates, and (x1,y1) are the top right coordinates. In order to do some calculations, we need to normalize the rectangle so that it is at the origin, measures 1.0 units on its longest axis, and is oriented so the longest axis is the y axis. Here is a function that does that, but checks that its input is correctly formatted and that its result makes sense:</p>
 <pre class="sourceCode matlab"><code class="sourceCode matlab">function normalized = normalize_rectangle(rect)
     <span class="co">% Normalizes a rectangle so that it is at the origin</span>
-    <span class="co">% and 1.0 units long on its longest axis:</span>
+    <span class="co">% measures 1.0 units on its longest axis</span>
+    <span class="co">% and is oriented with the longest axis in the y direction:</span>
 
     x0 = rect(<span class="fl">1</span>);
     y0 = rect(<span class="fl">2</span>);

--- a/06-defensive.md
+++ b/06-defensive.md
@@ -77,7 +77,7 @@ inside a piece of code.
 
 For example,
 suppose we are representing rectangles using an array
-of four coordinates `(x0, y0, x1, y1)`. In order to
+of four coordinates `(x0, y0, x1, y1)`, such that (x0,y0) are the bottom left coordinates, and (x1,y1) are the top right coordinates. In order to
 do some calculations, we need to normalize the rectangle
 so that it is at the origin, measures 1.0 units on its longest axis, and is oriented so the longest axis is the y axis.
 Here is a function that does that, but checks that its input is

--- a/06-defensive.md
+++ b/06-defensive.md
@@ -76,13 +76,13 @@ it finishes.
 inside a piece of code.
 
 For example,
-suppose we are representing rectangles using an array
-of four coordinates `(x0, y0, x1, y1)`, such that (x0,y0) are the bottom left coordinates, and (x1,y1) are the top right coordinates. In order to
-do some calculations, we need to normalize the rectangle
-so that it is at the origin, measures 1.0 units on its longest axis, and is oriented so the longest axis is the y axis.
-Here is a function that does that, but checks that its input is
-correctly formatted and that its result makes
-sense:
+suppose we are representing rectangles using an array of four coordinates 
+`(x0, y0, x1, y1)`, such that (x0,y0) are the bottom left coordinates, 
+and (x1,y1) are the top right coordinates. In order to do some calculations, 
+we need to normalize the rectangle so that it is at the origin, measures 1.0 
+units on its longest axis, and is oriented so the longest axis is the y axis.
+Here is a function that does that, but checks that its input is correctly 
+formatted and that its result makes sense:
 
 ~~~{.matlab}
 function normalized = normalize_rectangle(rect)
@@ -90,20 +90,20 @@ function normalized = normalize_rectangle(rect)
     % measures 1.0 units on its longest axis
 	% and is oriented with the longest axis in the y direction:
 
-    x0 = rect(1);
-    y0 = rect(2);
-    x1 = rect(3);
-    y1 = rect(4);
-
     assert(length(rect) == 4, 'Rectangle must contain 4 coordinates');
     assert(x0 < x1, 'Invalid X coordinates');
     assert(y0 < y1, 'Invalid Y coordinates');
 
+    x0 = rect(1);
+    y0 = rect(2);
+    x1 = rect(3);
+    y1 = rect(4); 
+    
     dx = x1 - x0;
     dy = y1 - y0;
 
     if dx > dy
-        scaled = dx/dy;
+        scaled = dx/dy; 
         upper_x = scaled;
         upper_y = 1.0;
     else
@@ -119,16 +119,14 @@ function normalized = normalize_rectangle(rect)
 end
 ~~~
 
-The first three preconditions catch invalid inputs.
+The three preconditions catch invalid inputs:
 
 ~~~ {.matlab}
 normalize_rectangle([0, 0, 1])
 ~~~
 ~~~{.error}
-Attempted to access rect(4); index out of bounds because numel(rect)=3.
-
-Error in normalize_rectangle (line 9)
-    y1 = rect(4);
+Error using normalize_rectangle (line 6)
+Rectangle must contain 4 coordinates 
 ~~~
 ~~~{.matlab}
 normalize_rectangle([1,0,0,0,0])
@@ -399,7 +397,7 @@ scientists tend to do the following:
  without re-running that program.
 
 4. *Check conservation laws.*
- Mass, energy, and other quantitites are conserved in physical systems,
+ Mass, energy, and other quantities are conserved in physical systems,
  so they should be in programs as well.
  Similarly,
  if we are analyzing patient data,

--- a/06-defensive.md
+++ b/06-defensive.md
@@ -75,14 +75,14 @@ it finishes.
 - An invariant is something that is always true at a particular point
 inside a piece of code.
 
-For example,
-suppose we are representing rectangles using an array of four coordinates 
+For example, suppose we are representing rectangles using an array of four coordinates 
 `(x0, y0, x1, y1)`, such that (x0,y0) are the bottom left coordinates, 
 and (x1,y1) are the top right coordinates. In order to do some calculations, 
 we need to normalize the rectangle so that it is at the origin, measures 1.0 
 units on its longest axis, and is oriented so the longest axis is the y axis.
 Here is a function that does that, but checks that its input is correctly 
 formatted and that its result makes sense:
+
 
 ~~~{.matlab}
 function normalized = normalize_rectangle(rect)


### PR DESCRIPTION
Normalise rectangle:
Moved precondition assertions above variable declarations, so that the
assertions catch invalid input, rather than MATLAB catching the out of
bounds error for the 3-element array example given.
Updated assert error message accordingly.

Other:
Typo correction, minor formatting

Updated some of the web pages that were out of date (06-defennsive still needs rebuilding).