### PR TITLE
minor grammar fix

### DIFF
--- a/_episodes/03-loops.md
+++ b/_episodes/03-loops.md
@@ -13,8 +13,7 @@ keypoints:
 - "Use `for` to create a loop that repeats one or more operations."
 ---
 
-Recall that we have to do this analysis for every one of our dozen datasets.
-And we need a better way than
+Recall that we have to do this analysis for every one of our dozen datasets, and we need a better way than
 typing out commands for each one,
 because we'll find ourselves writing a lot of duplicate code.
 Remember, code that is repeated in two or more places


### PR DESCRIPTION
Submitted by email as part of instructor training: 

I have noticed an error on the Matlab page on this link: http://swcarpentry.github.io/matlab-novice-inflammation/03-loops/ 

The page has the text below: 

Recall that we have to do this analysis for every one of our dozen datasets. And we need a better way than typing out commands for each one, because we'll find ourselves writing a lot of duplicate code. Remember, code that is repeated in two or more places will eventually be wrong in at least one. Also, if we make changes in the way we analyze our datasets, we have to introduce that change in every copy of our code. To avoid all of this repetition, we have to teach MATLAB to repeat our commands, and to do that, we have to learn how to write loops.

I believe that beginning a sentence with a conjunction is not correct and maybe we can change the highlighted text to rather begin with the word We and omit the And.