### PR TITLE
Instructor Checkout - added stride and loop body in glossary

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -113,6 +113,10 @@ library
 :   A family of code units (functions, classes, variables) that implement a set of
     related tasks.
 
+loop body
+:   The set of instructions appearing between the line with the `for` keyword and
+    the line with the `end` keyword.
+
 loop variable
 :   The variable that keeps track of the progress of the loop.
 
@@ -175,6 +179,10 @@ standard output
     data sent to standard output is displayed on the screen;
     in a [pipe](#pipe),
     it is passed to the [standard input](#standard-input) of the next process.
+
+stride
+:   The inter-element increment of a regularly-spaced list of integers, as generated
+    by MATLAB's colon operator.
 
 string
 :   Short for "character string",


### PR DESCRIPTION
Submission part of Software Carpentry Instructor checkout

The following changes have been made:
- added stride to the glossary (there was a link from stride in an Episode to the glossary without a corresponding entry)
- added loop body to the glossary (there was a link from loop body in an Episode to the glossary without a corresponding entry)