### PR TITLE
README links changed from python to matlab.  Fixes #88

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ matlab-novice-inflammation
 ==========================
 
 An introduction to MATLAB for non-programmers using inflammation data.
-Please see <https://swcarpentry.github.io/python-novice-inflammation/> for a rendered version of this material,
+Please see <https://swcarpentry.github.io/matlab-novice-inflammation/> for a rendered version of this material,
 [the lesson template documentation][lesson-example]
 for instructions on formatting, building, and submitting material,
 or run `make` in this directory for a list of helpful commands.


### PR DESCRIPTION
README links that linked incorrectly to python changed to matlab