### PR TITLE
Correct typo in explanation of vector dimensions

### DIFF
--- a/_episodes/01-intro.md
+++ b/_episodes/01-intro.md
@@ -307,7 +307,8 @@ that has 60 rows and 40 columns.
 MATLAB stores *all* data in the form of multi-dimensional arrays. For example:
 
 * Numbers, or *scalars* are represented as two dimensional arrays with only one row and one column, as are single characters. 
-* Lists of numbers, or *vectors* are two dimensional as well, but with the value of dimension being equal to one. By default vectors are row vectors, meaning they have one row and as many columns as there are elements in the vector.
+* Lists of numbers, or *vectors* are two dimensional as well, but the value of one of the dimensions equals one.
+  By default vectors are row vectors, meaning they have one row and as many columns as there are elements in the vector.
 * Tables of numbers, or *matrices* are arrays with more than one column and more than one row.
 * Even character strings, like sentences, are stored as an "array
 of characters".


### PR DESCRIPTION
Reword explanation of vectors -- it didn't make sense before.

Related #78.
Fix #61. (#78 fixes #61, but #61 hasn't been closed yet)