### PR TITLE
Auto-generate extras/figures page

### DIFF
--- a/_extras/figures.md
+++ b/_extras/figures.md
@@ -1,6 +1,40 @@
 ---
-layout: page
 title: Figures
-permalink: /figures/
 ---
-{% include all_figures.html %}
+<script>
+  window.onload = function() {
+    var lesson_episodes = [
+    {% for episode in site.episodes %}
+    "{{ episode.url}}"{% unless forloop.last %},{% endunless %}
+    {% endfor %}
+    ];
+    var xmlHttp = [];  /* Required since we are going to query every episode. */
+    for (i=0; i < lesson_episodes.length; i++) {
+      xmlHttp[i] = new XMLHttpRequest();
+      xmlHttp[i].episode = lesson_episodes[i];  /* To enable use this later. */
+      xmlHttp[i].onreadystatechange = function() {
+        if (this.readyState == 4 && this.status == 200) {
+          var article_here = document.getElementById(this.episode);
+          var parser = new DOMParser();
+          var htmlDoc = parser.parseFromString(this.responseText,"text/html");
+          var htmlDocArticle = htmlDoc.getElementsByTagName("article")[0];
+          article_here.appendChild(htmlDocArticle.getElementsByTagName("h1")[0]);
+          for (let image of htmlDocArticle.getElementsByTagName("img")) {
+            article_here.appendChild(image);
+          }
+        }
+      }
+      episode_url = "{{ page.root }}" + lesson_episodes[i];
+      xmlHttp[i].open("GET", episode_url);
+      xmlHttp[i].send(null);
+    }
+  }
+</script>
+{% comment %}
+Create anchor for each one of the episodes.
+{% endcomment %}
+{% for episode in site.episodes %}
+<article id="{{ episode.url }}"></article>
+{% endfor %}
+
+{% include links.md %}


### PR DESCRIPTION
The current page is static, and out of date - showing broken links
to deleted images.
This commit automatically regenerates the extras/figures page on build.

Related: https://github.com/carpentries/lesson-example/issues/222