### PR TITLE
Avoid intermediate variable for consistency

### DIFF
--- a/_episodes/01-intro.md
+++ b/_episodes/01-intro.md
@@ -861,8 +861,7 @@ so that other people can understand what it shows
 Let's take a look at the average inflammation over time:
 
 ~~~
-ave_inflammation = mean(patient_data, 1);
-plot(ave_inflammation)
+plot(mean(patient_data, 1))
 title('Daily average inflammation')
 xlabel('Day of trial')
 ylabel('Inflammation')
@@ -871,8 +870,7 @@ ylabel('Inflammation')
 
 ![Second Heat Map](../fig/01-intro_2.png)
 
-Here, we have put the average per day across all patients in the
-variable `ave_inflammation`, then used the `plot` function to display
+Here, we have calculated the average per day across all patients then used the `plot` function to display
 a line graph of those values.
 The result is roughly a linear rise and fall,
 which is suspicious:

--- a/_episodes/02-scripts.md
+++ b/_episodes/02-scripts.md
@@ -87,7 +87,7 @@ in the `results` directory:
 
 ~~~
 % Plot average inflammation per day
-plot(ave_inflammation)
+plot(mean(patient_data, 1))
 title('Daily average inflammation')
 xlabel('Day of trial')
 ylabel('Inflammation')
@@ -145,11 +145,9 @@ disp(['Maximum inflammation: ', num2str(max(patient_data(:)))])
 disp(['Minimum inflammation: ', num2str(min(patient_data(:)))])
 disp(['Standard deviation: ', num2str(std(patient_data(:)))])
 
-ave_inflammation = mean(patient_data, 1);
-
 % Plot inflammation stats for first patient
 subplot(1, 3, 1)
-plot(ave_inflammation)
+plot(mean(patient_data, 1))
 title('Average')
 ylabel('Inflammation')
 xlabel('Day')
@@ -188,13 +186,11 @@ disp(['Maximum inflammation: ', num2str(max(patient_data(:)))])
 disp(['Minimum inflammation: ', num2str(min(patient_data(:)))])
 disp(['Standard deviation: ', num2str(std(patient_data(:)))])
 
-ave_inflammation = mean(patient_data, 1);
-
 % Plot inflammation stats for first patient
 figure('visible', 'off')
 
 subplot(1, 3, 1)
-plot(ave_inflammation)
+plot(mean(patient_data, 1))
 title('Average')
 ylabel('inflammation')
 xlabel('Day')

--- a/_episodes/03-loops.md
+++ b/_episodes/03-loops.md
@@ -524,13 +524,11 @@ for idx = 1:3
     disp(['Minimum inflammation: ', num2str(min(patient_data(:)))])
     disp(['Standard deviation: ', num2str(std(patient_data(:)))])
 
-    ave_inflammation = mean(patient_data, 1);
-
     % Create figures
     figure('visible', 'off')
 
     subplot(2, 2, 1)
-    plot(ave_inflammation)
+    plot(mean(patient_data, 1))
     title('Average')
     ylabel('Inflammation')
     xlabel('Day')

--- a/_episodes/04-cond.md
+++ b/_episodes/04-cond.md
@@ -368,8 +368,6 @@ for idx = 1:3
 
     patient_data = csvread(file_name);
 
-    ave_inflammation = mean(patient_data, 1);
-
     % Create figures
     if plot_switch == 1
         figure('visible', 'off')
@@ -378,7 +376,7 @@ for idx = 1:3
     end
 
     subplot(2, 2, 1)
-    plot(ave_inflammation)
+    plot(mean(patient_data, 1))
     title('Average')
     ylabel('Inflammation')
     xlabel('Day')

--- a/_episodes/05-func.md
+++ b/_episodes/05-func.md
@@ -481,7 +481,6 @@ DATA centered around the value.
 > >     img_name = fullfile('results', img_name);
 > >
 > >     patient_data = csvread(file_name);
-> >     ave_inflammation = mean(patient_data, 1);
 > >     
 > >     if plot_switch == 1
 > >     	figure('visible', 'off')
@@ -490,7 +489,7 @@ DATA centered around the value.
 > >     end
 > >     
 > >     subplot(2, 2, 1)
-> >     plot(ave_inflammation)
+> >     plot(mean(patient_data, 1))
 > >     ylabel('average')
 > >     
 > >     subplot(2, 2, 2)


### PR DESCRIPTION
Nothing wrong with using it, but there doesn't appear to be a reason
for only having an intermediate variable for one calculation,
but not the rest.

Fix #173