### PR TITLE
Reorder print arguments to be consistent

### DIFF
--- a/_episodes/05-loops.md
+++ b/_episodes/05-loops.md
@@ -615,7 +615,7 @@ for i = 1:length(files)
     ylabel('Inflammation')
     xlabel('Day')
 
-    print('-dpng', img_name)
+    print(img_name, '-dpng')
     close()
 end
 ~~~

--- a/_episodes/06-cond.md
+++ b/_episodes/06-cond.md
@@ -318,7 +318,7 @@ If we would rather display the plots interactively,
 we would have to remove (or *comment out*) the following code:
 
 ~~~
-print('-dpng', img_name)
+print(img_name,'-dpng')
 close()
 ~~~
 {: .language-matlab}
@@ -394,7 +394,7 @@ for i = 1:length(files)
     xlabel('Day')
 
     if plot_switch == 1
-        print('-dpng', img_name)
+        print(img_name, '-dpng')
         close()
     end
 

--- a/_episodes/07-func.md
+++ b/_episodes/07-func.md
@@ -500,7 +500,7 @@ DATA centered around the value.
 > >     ylabel('min')
 > >     
 > >     if plot_switch == 1
-> >         print('-dpng', img_name)
+> >         print(img_name, '-dpng')
 > >         close()
 > >     end
 > >  end


### PR DESCRIPTION
Existing code works, but the order of arguments given in the
documentation is the other way round, and is inconsistent
throughout the episodes.