### PR TITLE
Add link to Unix Shell in introduction

### DIFF
--- a/index.md
+++ b/index.md
@@ -30,7 +30,7 @@ language *well*.
 >
 > To begin tackling this lesson, you will need to:
 >
-> * Understand the concepts of files and directories, and the concept of a "working directory".
+> * Understand the concepts of files and directories, and the concept of a "working directory". (A good place to start could be the ["Navigating Files and Directories"](https://swcarpentry.github.io/shell-novice/02-filedir/index.html) episode in ["The Unix Shell"](https://swcarpentry.github.io/shell-novice/) lesson)
 > * Know how to start up MATLAB, and access the *command window* (which generally has a `>>` prompt).
 > * Know how to create, edit and save text files.
 {: .prereq}


### PR DESCRIPTION
Hey, I was reading through the intro to this lesson, and noticed that one of the pre-requisites had some ties over to the "Unix Shell" episode around navigating files and directories. I was wondering if it was worth having a link to that included, in case an instructor wanted to have (for themselves) or give (for the learners) a quick refresher. 2 additional thoughts:
- Having it only linked to the Unix Shell limits accessibility for people who may be working on other platforms with similar concepts (e.g. Windows)
- Current wording disrupts the succinct flow of pre-requisites and so it may be more useful as a footnote for people to look at

---

Added links to the appropriate episode and lesson in the Unix Shell for further reading on the prerequisite  "Understand the concepts of files and directories, and the concept of a "working directory"

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
