### PR TITLE
Fix MATLAB syntax blocks in 'Testing a function'

### DIFF
--- a/episodes/07-func.md
+++ b/episodes/07-func.md
@@ -428,8 +428,7 @@ DATA centered around the value.
 ## Solution
 
 1. 
-````
-```
+```matlab
 function out = normalise(in)
     %NORMALISE   Return original array, normalised so that the
     %            new values lie in the range 0 to 1.
@@ -439,18 +438,13 @@ function out = normalise(in)
     out = (in-L)/(H-L);
 end
 ```
-{: .language-matlab}
-````
 
 2. 
-````
-```
+```matlab
 a = linspace(1, 10);   % Create evenly-spaced vector
 norm_a = normalise(a); % Normalise vector
 plot(a, norm_a)        % Visually check normalisation
 ```
-{: .language-matlab}
-````
 
 :::::::::::::::::::::::::
 


### PR DESCRIPTION
I found two solutions under [Testing a function](https://swcarpentry.github.io/matlab-novice-inflammation/instructor/07-func.html#testing-a-function) that were being rendered as:
````
```
function out = normalise(in)
    %NORMALISE   Return original array, normalised so that the
    %            new values lie in the range 0 to 1.

    H = max(max(in));
    L = min(min(in));
    out = (in-L)/(H-L);
end
```
{: .language-matlab}
````
and
````
```
a = linspace(1, 10);   % Create evenly-spaced vector
norm_a = normalise(a); % Normalise vector
plot(a, norm_a)        % Visually check normalisation
```
{: .language-matlab}
````
I suspect these are from the old style (pre-Workbench) lessons, so I mimicked the syntax used elsewhere for MATLABL function blocks, i.e.
````
```matlab
% code here
```
````