### PR TITLE
Update 02-arrays.md added info that Matlab starts indexes on 1, and a…

### DIFF
--- a/episodes/02-arrays.md
+++ b/episodes/02-arrays.md
@@ -59,8 +59,10 @@ its [index](../learners/reference.md#index) in parentheses:
 ans = 38
 ```
 
-Indices are provided as (row, column). So the index `(5, 6)` selects the element
-on the fifth row and sixth column.
+Indices are provided as (row, column). In Matlab, indexing starts at 1. 
+So the index `(5, 6)` selects the element on the fifth row and sixth column.
+
+![](fig/Matlab_Array_Indexes.svg){alt='8-by-8 matrix with rows for each label and column indicating their number. Rows numbered 1 to 8, as are columns'}
 
 An index like `(5, 6)` selects a single element of
 an array, but we can also access sections of the matrix, or [slices](../learners/reference.md#slice).


### PR DESCRIPTION
… labelled image.

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._


_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>

Partially closes  #258 as image to be added to Figs directory. Added text to state that Matlab indexing starts at 1, could have also noted that this isn't true for all languages.

Image added that shows row and column labels for the magic 8 matrix.
