### PR TITLE
Typo fixes

### DIFF
--- a/episodes/02-arrays.md
+++ b/episodes/02-arrays.md
@@ -217,7 +217,7 @@ last three characters: gen
       'gen'
   element(1:2:end) % Select every other element starting at first
   ans =
-      'oye
+      'oye'
   element(2:end-1) % Select elements starting with 2nd, until last-but-one
   ans =
       'xyge'

--- a/episodes/03-plotting.md
+++ b/episodes/03-plotting.md
@@ -373,7 +373,7 @@ Hint: search the documentation for *standard deviation*
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 It is often convenient to combine multiple plots into one figure
-using the `subplot`command which plots our graphs in a grid pattern.
+using the `subplot` command which plots our graphs in a grid pattern.
 The first two parameters describe the grid we want to use, while the third
 parameter indicates the placement on the grid.
 

--- a/episodes/04-scripts.md
+++ b/episodes/04-scripts.md
@@ -33,7 +33,7 @@ is just a text file with a `.m` extension. We've written
 commands to load data from a `.csv` file and
 display some plots of statistics about that data. Let's
 put those commands in a script called `plot_patient1.m`,
-which we'll save in our current directory,`matlab-novice-inflammation`.
+which we'll save in our current directory, `matlab-novice-inflammation`.
 
 To create a new script in the current directory, we use
 

--- a/episodes/05-loops.md
+++ b/episodes/05-loops.md
@@ -329,7 +329,7 @@ aluminum
 ```matlab
 % spell a string adding one letter at a time using a loop
 
-word = 'aluminium';
+word = 'aluminum';
 
 for letter = 1:length(word)
     disp(word(1:letter))
@@ -386,7 +386,7 @@ a
 ```matlab
 % Spell a string in reverse using a loop
 
-word = 'aluminium';
+word = 'aluminum';
 
 for letter = length(word):-1:1
     disp(word(letter))

--- a/episodes/06-cond.md
+++ b/episodes/06-cond.md
@@ -378,7 +378,7 @@ for i = 1:length(files)
     img_name = replace(file_name, '.csv', '.png');
 
     % Generate path to data file and image file
-    file_name = fullfile('data', filename);
+    file_name = fullfile('data', file_name);
     img_name  = fullfile('results', img_name);
 
     patient_data = readmatrix(file_name);

--- a/episodes/06-cond.md
+++ b/episodes/06-cond.md
@@ -277,7 +277,7 @@ disp(['sum of negative values: ', num2str(neg_total)])
 ```
 
 ```output
-sum of positive values: 26
+sum of positive values: 20
 sum of negative values: -6
 ```
 

--- a/episodes/08-defensive.md
+++ b/episodes/08-defensive.md
@@ -321,6 +321,7 @@ function varlist(varargin)
 
    fprintf('Number of arguments: %d\n',nargin)
    celldisp(varargin)
+end
 ```
 
 ```matlab
@@ -378,6 +379,7 @@ function overlap = range_overlap(________)
     end
 
     overlap = [lowest, highest];
+end
 ```
 
 :::::::::::::::  solution
@@ -402,6 +404,7 @@ function overlap = range_overlap(varargin)
     end
 
     overlap = [lowest, highest];
+end
 ```
 
 :::::::::::::::::::::::::
@@ -468,6 +471,7 @@ function overlap = range_overlap(varargin)
     end
 
     overlap = [lowest, highest];
+end
 ```
 
 :::::::::::::::::::::::::

--- a/episodes/08-defensive.md
+++ b/episodes/08-defensive.md
@@ -133,7 +133,7 @@ The three preconditions catch invalid inputs:
 ```
 
 ```error
-Error using normalize_rectangle (line 6)
+Error using normalize_rectangle (line 7)
 Rectangle must contain 4 coordinates
 ```
 
@@ -177,7 +177,7 @@ the assertion is triggered:
 error: Calculated upper X coordinate invalid
 ```
 
-Re-reading our function, we realize that line 19 should
+Re-reading our function, we realize that line 20 should
 divide `dy` by `dx`. If we had left out the assertion
 at the end of the function, we would have created and
 returned something that had the right shape as

--- a/episodes/08-defensive.md
+++ b/episodes/08-defensive.md
@@ -465,7 +465,7 @@ function overlap = range_overlap(varargin)
         
         % Catch non-overlapping ranges
 	    if low >= highest || high<=lowest
-            output_range = NaN;
+            overlap = NaN;
             return
 	    end
     end

--- a/episodes/08-defensive.md
+++ b/episodes/08-defensive.md
@@ -177,7 +177,7 @@ the assertion is triggered:
 error: Calculated upper X coordinate invalid
 ```
 
-Re-reading our function, we realize that line 20 should
+Re-reading our function, we realize that line 21 should
 divide `dy` by `dx`. If we had left out the assertion
 at the end of the function, we would have created and
 returned something that had the right shape as
@@ -294,7 +294,7 @@ test_range_overlap
 ```error
 Undefined function or variable 'range_overlap'.
 
-Error in test_range_overlap (line 6)
+Error in test_range_overlap (line 5)
 assert(isequal(range_overlap([0, 1.0]),[0, 1.0]))
 ```
 


### PR DESCRIPTION
Closes #263 

This PR fixes some typos throughout the course. Some of these were minor (missing punctuation) but some were more considerable, for instance:
- Exercises ask learners to perform operations on the string `'aluminum'`, while the solutions use `'aluminium'`.
- A calculation to sum the positive values in an array stated the incorrect result (despite the function being correct)
- There was a reference to a variable 'filename', which should have been 'file_name'
- There was a reference to a variable 'output_range', which should have been 'overlap' - this caused assertions to fail
- References to line numbers have been updated
- `end` statements have been added to functions where missing

