### PR TITLE
Removed instruction to create results directory

### DIFF
--- a/episodes/01-intro.md
+++ b/episodes/01-intro.md
@@ -263,12 +263,10 @@ It recommends the following for project organization:
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-We already have a `data` directory in our `matlab-novice-inflammation` project directory,
-so we only need to create a `results` directory for this project.
-You can use your computer's file browser to create this directory.
-We'll save all our scripts and function files in the main project directory.
+Our main project directory is `matlab-novice-inflammation`, where we'll save all our
+scripts and function files. We already have `data` and `results` directories here.
 
-A final step is to set the *current folder* in MATLAB to our project folder.
+A crucial step is to set the *current folder* in MATLAB to our project directory.
 Use the **Current Folder** window in the MATLAB GUI to browse to your project folder
 (`matlab-novice-inflammation`).
 


### PR DESCRIPTION
Closes #237

This PR removes the instruction to create the empty "results" directory, since it is included in the zip archive as of https://github.com/swcarpentry/matlab-novice-inflammation/commit/936db84f410b50d87ea52ace35243d4a5ce3debf